### PR TITLE
Rewrite layout to use CSS Grid

### DIFF
--- a/src/examples/preact-10.js
+++ b/src/examples/preact-10.js
@@ -54,7 +54,7 @@ export function StyleGuide() {
 
 	return (
 		<div class={theme === "auto" ? "dark" : theme}>
-			<div style="padding: 5rem" class={d.root}>
+			<div style="padding: 5rem" class={d.theme}>
 				<div style="display: flex; flex-direction: column;">
 					<h2>Todo List</h2>
 					<TodoList />

--- a/src/view/components/Devtools.css
+++ b/src/view/components/Devtools.css
@@ -1,21 +1,27 @@
 .root {
-	min-width: 100%;
-	height: 100%;
-	display: flex;
-	flex-direction: row;
+	height: 100vh;
+	display: grid;
+	grid-template-columns: auto 35%;
+	grid-template-rows: 2.25rem 1fr;
+	grid-template-areas:
+		"treeActions sidebarActions"
+		"tree sidebar";
+}
+
+.theme {
 	background: var(--color-bg);
 	color: var(--color-text);
 }
 
-.root button::-moz-focus-inner {
+.theme button::-moz-focus-inner {
 	border: none;
 }
 
-.root input {
+.theme input {
 	margin: 0;
 }
 
-:global(.light) .root {
+:global(.light) .theme {
 	--color-bg: white;
 	--color-text: #333;
 	--color-selected-bg: #8058ca;
@@ -56,7 +62,7 @@
 	--color-props-vnode: #1b1b1b;
 }
 
-:global(.dark) .root {
+:global(.dark) .theme {
 	--color-bg: #242424;
 	--color-text: #b0b0b0;
 	--color-selected-bg: #ae80ff;
@@ -98,18 +104,22 @@
 	--color-props-vnode: #dedede;
 }
 
+.componentActions {
+	grid-area: treeActions;
+}
+
 .components {
-	display: flex;
-	flex: 0 0 65%;
-	width: 65%;
-	flex-direction: column;
+	grid-area: tree;
+	overflow: auto;
+}
+
+.sidebarActions {
+	grid-area: sidebarActions;
+	border-left: 0.0625rem solid var(--color-border);
 }
 
 .sidebar {
-	display: flex;
-	flex: 0 0 35%;
-	width: 35%;
-	overflow-x: hidden;
-	flex-direction: column;
+	grid-area: sidebar;
 	border-left: 0.0625rem solid var(--color-border);
+	overflow: auto;
 }

--- a/src/view/components/Devtools.tsx
+++ b/src/view/components/Devtools.tsx
@@ -7,16 +7,22 @@ import { AppCtx, EmitCtx } from "../store/react-bindings";
 import { ModalRenderer } from "./Modals";
 import { Store } from "../store/types";
 import { ThemeSwitcher } from "./ThemeSwitcher";
+import { SidebarActions } from "./sidebar/SidebarActions";
 
 export function DevTools(props: { store: Store }) {
 	return (
 		<EmitCtx.Provider value={props.store.emit}>
 			<AppCtx.Provider value={props.store}>
-				<div class={s.root}>
+				<div class={s.root + " " + s.theme}>
 					<ThemeSwitcher />
-					<div class={s.components}>
+					<div class={s.componentActions}>
 						<TreeBar />
+					</div>
+					<div class={s.components}>
 						<TreeView />
+					</div>
+					<div class={s.sidebarActions}>
+						<SidebarActions />
 					</div>
 					<div class={s.sidebar}>
 						<Sidebar />

--- a/src/view/components/ThemeSwitcher.tsx
+++ b/src/view/components/ThemeSwitcher.tsx
@@ -21,5 +21,5 @@ export function ThemeSwitcher() {
 		}
 	}, [theme, ref.current]);
 
-	return <div ref={ref} />;
+	return <div ref={ref} style="display: none" />;
 }

--- a/src/view/components/sidebar/Sidebar.css
+++ b/src/view/components/sidebar/Sidebar.css
@@ -1,18 +1,7 @@
-.root {
-	display: flex;
-	flex-direction: column;
-	width: 100%;
-	height: 100%;
-}
-
 .title {
 	color: var(--color-element-text);
 	font-family: monospace;
 	font-size: 1rem;
-}
-
-.body {
-	overflow: auto;
 }
 
 .body > * + * {

--- a/src/view/components/sidebar/Sidebar.tsx
+++ b/src/view/components/sidebar/Sidebar.tsx
@@ -1,10 +1,9 @@
-import { h } from "preact";
+import { h, Fragment } from "preact";
 import s from "./Sidebar.css";
 import { useEmitter } from "../../store/react-bindings";
 import { PropsPanel } from "./PropsPanel";
 import { PropData } from "./parseProps";
 import { Collapser } from "../../store/collapser";
-import { SidebarActions } from "./SidebarActions";
 import { serializeProps } from "./serializeProps";
 import { useCallback } from "preact/hooks";
 
@@ -28,46 +27,41 @@ export function Sidebar() {
 	const onCopy = useCallback((v: any) => emit("copy", serializeProps(v)), []);
 
 	return (
-		<aside class={s.root}>
-			<SidebarActions />
-			<div class={s.body}>
-				<PropsPanel
-					label="Props"
-					getData={d => d.props}
-					checkEditable={data => data.canEditProps}
-					transform={collapseFn}
-					onChange={(id, path, value) =>
-						emit("update-prop", { id, path, value })
-					}
-					onCopy={onCopy}
-					canAddNew
-				/>
-				<PropsPanel
-					label="State"
-					isOptional
-					getData={d => d.state}
-					checkEditable={data => data.canEditState}
-					transform={collapseFn}
-					onChange={(id, path, value) =>
-						emit("update-state", { id, path, value })
-					}
-					onCopy={onCopy}
-				/>
-				<PropsPanel
-					label="Context"
-					isOptional
-					getData={d => d.context}
-					checkEditable={() => true}
-					transform={collapseFn}
-					onChange={(id, path, value) =>
-						emit("update-context", { id, path, value })
-					}
-					onCopy={onCopy}
-				/>
-				{/* {inspect != null && inspect.hooks && (
+		<Fragment>
+			<PropsPanel
+				label="Props"
+				getData={d => d.props}
+				checkEditable={data => data.canEditProps}
+				transform={collapseFn}
+				onChange={(id, path, value) => emit("update-prop", { id, path, value })}
+				onCopy={onCopy}
+				canAddNew
+			/>
+			<PropsPanel
+				label="State"
+				isOptional
+				getData={d => d.state}
+				checkEditable={data => data.canEditState}
+				transform={collapseFn}
+				onChange={(id, path, value) =>
+					emit("update-state", { id, path, value })
+				}
+				onCopy={onCopy}
+			/>
+			<PropsPanel
+				label="Context"
+				isOptional
+				getData={d => d.context}
+				checkEditable={() => true}
+				transform={collapseFn}
+				onChange={(id, path, value) =>
+					emit("update-context", { id, path, value })
+				}
+				onCopy={onCopy}
+			/>
+			{/* {inspect != null && inspect.hooks && (
 					<SidebarPanel title="hooks" empty="None"></SidebarPanel>
 				)} */}
-			</div>
-		</aside>
+		</Fragment>
 	);
 }


### PR DESCRIPTION
This fixes a layout issue where a wide component tree would force the devtools to be wider than the viewport.