### PR TITLE
Adapt indentation based on available screen space

### DIFF
--- a/src/view/components/elements/TreeView.css
+++ b/src/view/components/elements/TreeView.css
@@ -13,6 +13,16 @@
 	user-select: none;
 	min-height: 15rem;
 	height: 100%;
+
+	overflow-x: hidden;
+}
+
+.pane {
+	/**
+	 * Hack to get the parent to grow with its children, see:
+	 * https://stackoverflow.com/questions/17291514/how-to-force-parent-div-to-expand-by-child-div-width-padding-margin-box
+	 */
+	display: inline-block;
 }
 
 .empty {
@@ -21,7 +31,7 @@
 	justify-content: center;
 	align-items: center;
 	height: 100%;
-	remin-height: 15rem;
+	min-height: 15rem;
 }
 
 .bgLogo {
@@ -39,11 +49,31 @@
 	font-family: monospace;
 	color: var(--color-element-text);
 	height: 1.5rem;
+	position: relative;
 }
 
 .tree:focus-within .item[data-selected] {
 	background: var(--color-selected-bg);
 	color: var(--color-selected-text);
+}
+
+.tree:focus-within .item[data-selected]::after,
+.tree .item[data-selected]::after,
+.item:not([data-selected]):hover::after {
+	content: "";
+	position: absolute;
+	left: 100%;
+	top: 0;
+	bottom: 0;
+	width: 100%;
+}
+
+.tree:focus-within .item[data-selected]::after {
+	background: var(--color-selected-bg);
+}
+
+.tree .item[data-selected]::after {
+	background: var(--color-selected-inactive-bg);
 }
 
 .item[data-selected] {
@@ -52,6 +82,10 @@
 }
 
 .item:not([data-selected]):hover {
+	background: var(--color-hover);
+}
+
+.item:not([data-selected]):hover::after {
 	background: var(--color-hover);
 }
 

--- a/src/view/components/elements/TreeView.tsx
+++ b/src/view/components/elements/TreeView.tsx
@@ -75,15 +75,15 @@ export function TreeView() {
 			data-tree={true}
 			onMouseLeave={onMouseLeave}
 		>
+			{nodeList.length === 0 && (
+				<div class={s.empty}>
+					<BackgroundLogo class={s.bgLogo} />
+					<p>
+						<b>Connected</b>, waiting for nodes to load...
+					</p>
+				</div>
+			)}
 			<div class={s.pane} ref={paneRef}>
-				{nodeList.length === 0 && (
-					<div class={s.empty}>
-						<BackgroundLogo class={s.bgLogo} />
-						<p>
-							<b>Connected</b>, waiting for nodes to load...
-						</p>
-					</div>
-				)}
 				{nodeList.map(id => (
 					<TreeItem key={id} id={id} />
 				))}

--- a/src/view/components/tree/windowing.test.ts
+++ b/src/view/components/tree/windowing.test.ts
@@ -3,16 +3,17 @@ import { flattenChildren } from "./windowing";
 import { ID } from "../../store/types";
 
 describe("flattenChildren", () => {
+	let tree = new Map<ID, { id: ID; children: ID[]; depth: number }>();
+	tree.set(1, { id: 1, children: [2, 3, 6], depth: 1 });
+	tree.set(2, { id: 2, children: [4], depth: 2 });
+	tree.set(3, { id: 3, children: [5], depth: 2 });
+	tree.set(4, { id: 4, children: [], depth: 3 });
+	tree.set(5, { id: 5, children: [], depth: 3 });
+	tree.set(6, { id: 6, children: [], depth: 2 });
+
 	it("should flatten tree", () => {
 		let collapsed = new Set<ID>();
-		let tree = new Map<ID, { id: ID; children: ID[] }>();
-		tree.set(1, { id: 1, children: [2, 3, 6] });
-		tree.set(2, { id: 2, children: [4] });
-		tree.set(3, { id: 3, children: [5] });
-		tree.set(4, { id: 4, children: [] });
-		tree.set(5, { id: 5, children: [] });
-		tree.set(6, { id: 6, children: [] });
-		expect(flattenChildren(tree, 1, collapsed)).to.deep.equal([
+		expect(flattenChildren(tree, 1, collapsed).items).to.deep.equal([
 			1,
 			2,
 			4,
@@ -20,5 +21,9 @@ describe("flattenChildren", () => {
 			5,
 			6,
 		]);
+	});
+
+	it("should return maxDepth", () => {
+		expect(flattenChildren(tree, 1, new Set<ID>()).maxDepth).to.equal(3);
 	});
 });

--- a/src/view/components/tree/windowing.ts
+++ b/src/view/components/tree/windowing.ts
@@ -1,13 +1,13 @@
 import { ID } from "../../store/types";
 
-export function flattenChildren<K, T extends { id: K; children: K[] }>(
-	tree: Map<K, T>,
-	id: K,
-	collapsed: Set<K>,
-): K[] {
+export function flattenChildren<
+	K,
+	T extends { id: K; children: K[]; depth: number }
+>(tree: Map<K, T>, id: K, collapsed: Set<K>): { maxDepth: number; items: K[] } {
 	const out: K[] = [];
 	const visited = new Set<K>();
 	let stack: K[] = [id];
+	let maxDepth = 1;
 
 	while (stack.length > 0) {
 		const item = stack.pop();
@@ -20,6 +20,10 @@ export function flattenChildren<K, T extends { id: K; children: K[] }>(
 			out.push(node.id);
 			visited.add(node.id);
 
+			if (node.depth > maxDepth) {
+				maxDepth = node.depth;
+			}
+
 			if (!collapsed.has(node.id)) {
 				for (let i = node.children.length; i--; ) {
 					stack.push(node.children[i]);
@@ -28,7 +32,7 @@ export function flattenChildren<K, T extends { id: K; children: K[] }>(
 		}
 	}
 
-	return out;
+	return { maxDepth, items: out };
 }
 
 export function clamp(n: number, max: number) {

--- a/src/view/components/utils.ts
+++ b/src/view/components/utils.ts
@@ -31,6 +31,19 @@ export function scrollIntoView(el: HTMLElement) {
 	}
 }
 
+export function cssToPx(raw: string) {
+	if (raw.endsWith("rem")) {
+		const rem = parseFloat(raw.slice(0, -3));
+		return (
+			rem * parseFloat(getComputedStyle(document.documentElement).fontSize)
+		);
+	} else if (raw.endsWith("px")) {
+		return parseFloat(raw.slice(0, -2));
+	}
+
+	throw new Error(`Conversion of ${raw} is not supported yet`);
+}
+
 export function getRootDomNode(el: HTMLElement): HTMLElement {
 	let item = el;
 	while (item.parentNode != null) {

--- a/src/view/store/index.ts
+++ b/src/view/store/index.ts
@@ -26,19 +26,28 @@ export function createStore(): Store {
 	// List
 	const collapsed = valoo(new Set<ID>());
 	const collapser = createCollapser<ID>(collapsed);
+	const treeDepth = valoo<number>(0);
+
 	const nodeList = watch(() => {
 		return roots.$.map(root => {
-			const list = flattenChildren<ID, DevNode>(
+			const { items, maxDepth } = flattenChildren<ID, DevNode>(
 				nodes.$,
 				root,
 				collapser.collapsed.$,
 			);
 
 			if (filterState.filterFragment.$) {
-				return list.slice(1);
+				if (maxDepth - 1 > treeDepth.$) {
+					treeDepth.$ = maxDepth - 1;
+				}
+				return items.slice(1);
 			}
 
-			return list;
+			if (maxDepth > treeDepth.$) {
+				treeDepth.$ = maxDepth;
+			}
+
+			return items;
 		}).flat();
 	});
 
@@ -62,6 +71,7 @@ export function createStore(): Store {
 		roots,
 		nodes,
 		collapser,
+		treeDepth,
 		search: createSearchStore(nodes, nodeList),
 		filter: filterState,
 		selection,

--- a/src/view/store/props.ts
+++ b/src/view/store/props.ts
@@ -59,8 +59,8 @@ export function createPropsStore(
 	});
 
 	const list = watch(() => {
-		const ids = flattenChildren(tree.$, "root", collapser.collapsed.$);
-		return ids.slice(1);
+		const { items } = flattenChildren(tree.$, "root", collapser.collapsed.$);
+		return items.slice(1);
 	});
 
 	return { list, collapser, tree, destroy: () => dispose() };

--- a/src/view/store/types.ts
+++ b/src/view/store/types.ts
@@ -54,6 +54,7 @@ export interface Store {
 	nodes: Observable<Tree>;
 	nodeList: Observable<ID[]>;
 	theme: Observable<Theme>;
+	treeDepth: Observable<number>;
 	search: ReturnType<typeof createSearchStore>;
 	filter: ReturnType<typeof createFilterStore>;
 	selection: ReturnType<typeof createSelectionStore>;


### PR DESCRIPTION
Main point is that the user never has to scroll horizontally :tada: 

Bugs:

- [x] When the tree is scaled down again, the highlighting is visually cut-off