### PR TITLE
Don't animate scroll in tree view

### DIFF
--- a/src/view/components/utils.ts
+++ b/src/view/components/utils.ts
@@ -27,7 +27,6 @@ export function scrollIntoView(el: HTMLElement) {
 		}
 		parent.scrollTo({
 			top,
-			behavior: "smooth",
 		});
 	}
 }


### PR DESCRIPTION
The animation is too slow and distracting when the element picker is used.