### PR TITLE
Set fallback component name

### DIFF
--- a/src/adapter/10/renderer.test.tsx
+++ b/src/adapter/10/renderer.test.tsx
@@ -180,6 +180,22 @@ describe("Renderer 10", () => {
 		]);
 	});
 
+	it("should set a fallback name", () => {
+		const Foo = () => <div>foo</div>;
+		Object.defineProperty(Foo, "name", {
+			get: () => "",
+		});
+
+		render(<Foo />, scratch);
+
+		expect(toSnapshot(spy.args[0][1])).to.deep.equal([
+			"rootId: 1",
+			"Add 1 <Fragment> to parent -1",
+			"Add 2 <Anonymous> to parent 1",
+			"Add 3 <div> to parent 2",
+		]);
+	});
+
 	describe("filters", () => {
 		it("should apply regex filters", () => {
 			renderer.applyFilters({

--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -96,9 +96,9 @@ export function getAncestor(vnode: VNode) {
  */
 export function getDisplayName(vnode: VNode, config: RendererConfig10) {
 	if (vnode.type === config.Fragment) return "Fragment";
-	else if (typeof vnode.type === "function")
-		return vnode.type.displayName || vnode.type.name;
-	else if (typeof vnode.type === "string") return vnode.type;
+	else if (typeof vnode.type === "function") {
+		return vnode.type.displayName || vnode.type.name || "Anonymous";
+	} else if (typeof vnode.type === "string") return vnode.type;
 	return "#text";
 }
 


### PR DESCRIPTION
We didn't set a fallback name for arrow function components which may have an empty string as `function.name`. Found while debugging #61 :tada: 