### PR TITLE
Merge pull request #63 from preactjs/special-jsx-props

### DIFF
--- a/src/adapter/10/utils.test.tsx
+++ b/src/adapter/10/utils.test.tsx
@@ -2,7 +2,7 @@ import { h, Component, createContext, render } from "preact";
 import { teardown } from "preact/test-utils";
 import { setupScratch } from "./renderer.test";
 import { expect } from "chai";
-import { cleanContext } from "./utils";
+import { cleanContext, cleanProps } from "./utils";
 
 describe("cleanContext", () => {
 	let scratch: HTMLDivElement;
@@ -50,5 +50,22 @@ describe("cleanContext", () => {
 
 	it("should return null when no context value is present", () => {
 		expect(cleanContext({})).to.equal(null);
+	});
+});
+
+describe("cleanProps", () => {
+	it("should return null if props is empty", () => {
+		const vnode = h("div", {});
+		expect(cleanProps(vnode.props)).to.equal(null);
+	});
+
+	it("should filter out __source", () => {
+		const vnode = h("div", { __source: "foo", foo: 1 });
+		expect(cleanProps(vnode.props)).to.deep.equal({ foo: 1 });
+	});
+
+	it("should filter out __self", () => {
+		const vnode = h("div", { __self: "foo", foo: 1 });
+		expect(cleanProps(vnode.props)).to.deep.equal({ foo: 1 });
 	});
 });

--- a/src/adapter/10/utils.test.tsx
+++ b/src/adapter/10/utils.test.tsx
@@ -3,6 +3,7 @@ import { teardown } from "preact/test-utils";
 import { setupScratch } from "./renderer.test";
 import { expect } from "chai";
 import { cleanContext, cleanProps } from "./utils";
+import { getActualChildren } from "./vnode";
 
 describe("cleanContext", () => {
 	let scratch: HTMLDivElement;
@@ -54,9 +55,33 @@ describe("cleanContext", () => {
 });
 
 describe("cleanProps", () => {
+	let scratch: HTMLDivElement;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown();
+		scratch.remove();
+	});
+
 	it("should return null if props is empty", () => {
 		const vnode = h("div", {});
 		expect(cleanProps(vnode.props)).to.equal(null);
+	});
+
+	it("should bail out if props is null", () => {
+		const vnode = h("div", null);
+		expect(cleanProps(vnode.props)).to.equal(null);
+	});
+
+	it("should return null for text vnodes", () => {
+		const parent = h("div", {}, "foo");
+		render(parent, scratch);
+
+		const child = getActualChildren(parent)[0]!;
+		expect(cleanProps(child.props)).to.equal(null);
 	});
 
 	it("should filter out __source", () => {

--- a/src/adapter/10/utils.ts
+++ b/src/adapter/10/utils.ts
@@ -49,9 +49,15 @@ export function jsonify(
 	}
 }
 
-export function cleanProps(props: any) {
+export function cleanProps<T extends object>(
+	props: T,
+): Exclude<T, "__source" | "__self"> | null {
 	if (typeof props === "string" || !props) return null;
-	const out = { ...props };
+	let out: any = {};
+	for (let key in props) {
+		if (key === "__source" || key === "__self") continue;
+		out[key] = props[key];
+	}
 	if (!Object.keys(out).length) return null;
 	return out;
 }


### PR DESCRIPTION
This PR removes `__self` and `__source` from props. Those are inserted by various babel plugins and are meant to help with owners or custom stack traces. So they should be invisible to the user.