### PR TITLE
Add privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,17 @@
+# Privacy Policy
+
+## What type of data does the extension collect?
+
+**None**, your data is yours and we do not want it. The extension does not collect any data. It never communicates in any form over the network.
+
+## What data does the extension store?
+
+Any options you may set in the `Settings` tab are saved, so that they don't get lost when you close and re-open your browser.
+
+## How can I be informed of any changes to the privacy policy?
+
+Since we don't collect any information on you, we also cannot notify you of changes to this privacy policy. To receive updates, please subscribe to this repository on Github.
+
+## How can I ask questions about this policy?
+
+You can ask questions by filing an issue in the [issue tracker](https://github.com/preactjs/preact-devtools/issues) on GitHub.


### PR DESCRIPTION
The edge store rejected our extension on the base of a lack of a privacy policy. This is pretty confusing as we do not track or collect data in any way at all. In fact we never do any network requests at all :man_shrugging: 