### PR TITLE
Fix infinite loop on circular references in props

### DIFF
--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -150,8 +150,10 @@ export function createRenderer(
 			const hasHooks = c != null && getComponentHooks(c) != null;
 			const context =
 				c != null
-					? jsonify(cleanContext(c.context), node =>
-							serializeVNode(node, config),
+					? jsonify(
+							cleanContext(c.context),
+							node => serializeVNode(node, config),
+							new Set(),
 					  )
 					: null;
 
@@ -164,13 +166,15 @@ export function createRenderer(
 				canEditProps: true,
 				props:
 					vnode.type !== null
-						? jsonify(cleanProps(vnode.props), node =>
-								serializeVNode(node, config),
+						? jsonify(
+								cleanProps(vnode.props),
+								node => serializeVNode(node, config),
+								new Set(),
 						  )
 						: null,
 				canEditState: true,
 				state: hasState
-					? jsonify(c!.state, node => serializeVNode(node, config))
+					? jsonify(c!.state, node => serializeVNode(node, config), new Set())
 					: null,
 				type: 2,
 			};

--- a/src/examples/10/Circular.tsx
+++ b/src/examples/10/Circular.tsx
@@ -1,0 +1,12 @@
+import { h } from "../vendor/preact-10";
+
+const props: any = { foo: 123, bar: 123 };
+props.foo = props;
+
+function CircularInner() {
+	return <h1>Circular</h1>;
+}
+
+export function Circular() {
+	return <CircularInner {...props} />;
+}

--- a/src/examples/10/setup.tsx
+++ b/src/examples/10/setup.tsx
@@ -9,6 +9,7 @@ import { setupOptions } from "../../adapter/10/options";
 import { Booleans, Complex } from "./DataTypes";
 import { FullWidthHighlighter } from "./Highlighting";
 import { Gradient } from "./Gradient";
+import { Circular } from "./Circular";
 import s from "../../view/components/Devtools.css";
 import { Prime } from "./Prime";
 
@@ -52,6 +53,7 @@ export function renderExamples10(node: HTMLElement) {
 				<Gradient />
 				<p>Deep tree</p>
 				<DeepTree /> */}
+				<Circular />
 				<br />
 			</div>
 		</div>,

--- a/src/view/components/DataInput/parseValue.ts
+++ b/src/view/components/DataInput/parseValue.ts
@@ -81,6 +81,9 @@ export function displayCollection(v: any): string {
 		}
 		return "Object";
 	}
-	if (typeof v === "string") return `"${v}"`;
+	if (typeof v === "string") {
+		if (v === "[[Circular]]") return v;
+		return `"${v}"`;
+	}
 	return "" + (v === undefined ? "" : v);
 }

--- a/src/view/components/sidebar/ElementProps.tsx
+++ b/src/view/components/sidebar/ElementProps.tsx
@@ -41,7 +41,7 @@ export function ElementProps(props: Props) {
 							collapseable={item.collapsable}
 							collapsed={collapsed.has(id)}
 							onCollapse={() => onCollapse && onCollapse(id)}
-							editable={editable}
+							editable={editable && item.editable}
 							value={item.value}
 							path={item.path}
 							onChange={onChange}

--- a/src/view/components/sidebar/parseProps.test.ts
+++ b/src/view/components/sidebar/parseProps.test.ts
@@ -284,4 +284,21 @@ describe("flatten", () => {
 			},
 		]);
 	});
+
+	it("should not mark [[Circular]] reference as editable", () => {
+		const tree = new Map();
+		parseProps("[[Circular]]", [], 2, noop, tree);
+		expect(serialize(tree)).to.deep.equal([
+			{
+				collapsable: false,
+				editable: false,
+				depth: 0,
+				id: "",
+				path: [],
+				type: "string",
+				value: "[[Circular]]",
+				children: [],
+			},
+		]);
+	});
 });

--- a/src/view/components/sidebar/parseProps.ts
+++ b/src/view/components/sidebar/parseProps.ts
@@ -199,7 +199,7 @@ export function parseProps(
 				id: pathStr,
 				type: type as any,
 				collapsable: false,
-				editable: type !== "undefined",
+				editable: type !== "undefined" && data !== "[[Circular]]",
 				path,
 				value: data,
 				children: [],


### PR DESCRIPTION
Up to know we didn't have any sort of protections against circular references. This can happen quite frequently in `props` when context is in play and would lead to infinite loops. With this PR we display any circular references as `[[Circular]]` similar to browsers.

This PR is work in progress.

Fixes #79 .