### PR TITLE
Fix race condition when injecting devtools hook

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import copy from "rollup-plugin-copy";
 import resolve from "rollup-plugin-node-resolve";
 import postcss from "rollup-plugin-postcss";
 import commonjs from "rollup-plugin-commonjs";
+import path from "path";
 
 const BROWSERS = ["chrome", "edge", "firefox"].filter(x => {
 	if (process.env.BROWSER) {
@@ -63,11 +64,13 @@ if (!process.env.BROWSER) {
 	);
 }
 
+const camelCase = str => str.replace(/-(\w)/g, (_, x) => x.toUpperCase());
+
 export default entries.map(data => ({
 	input: data.entry,
 	output: {
 		file: data.dist,
-		name: "index.js",
+		name: camelCase(path.basename(data.dist, path.extname(data.dist))),
 		format: "iife",
 	},
 	external: data.external || [],

--- a/src/shells/chrome/manifest.json
+++ b/src/shells/chrome/manifest.json
@@ -34,10 +34,5 @@
 			"run_at": "document_start"
 		}
 	],
-	"web_accessible_resources": [
-		"installHook.js",
-		"installHook.css",
-		"panel.html",
-		"devtools.html"
-	]
+	"web_accessible_resources": ["installHook.css", "panel.html", "devtools.html"]
 }

--- a/src/shells/edge/manifest.json
+++ b/src/shells/edge/manifest.json
@@ -34,10 +34,5 @@
 			"run_at": "document_start"
 		}
 	],
-	"web_accessible_resources": [
-		"installHook.js",
-		"installHook.css",
-		"panel.html",
-		"devtools.html"
-	]
+	"web_accessible_resources": ["installHook.css", "panel.html", "devtools.html"]
 }

--- a/src/shells/firefox/manifest.json
+++ b/src/shells/firefox/manifest.json
@@ -38,10 +38,5 @@
 			"run_at": "document_start"
 		}
 	],
-	"web_accessible_resources": [
-		"installHook.js",
-		"installHook.css",
-		"panel.html",
-		"devtools.html"
-	]
+	"web_accessible_resources": ["installHook.css", "panel.html", "devtools.html"]
 }

--- a/src/shells/shared/initClient.ts
+++ b/src/shells/shared/initClient.ts
@@ -26,6 +26,21 @@ window.addEventListener("pageshow", ev => {
 
 // Only inject for HTML pages
 if (document.contentType === "text/html") {
-	inject(chrome.runtime.getURL("installHook.js"), "script");
+	// We need to inject in time to catch the initial mount. There is no
+	// reliable way to ensure that our code runs before the page's javascript.
+	// Using a script tag with an src attribute leads to a race condition
+	// where the page's js will be run before us when it's cached by the
+	// browser or by a service worker.
+	//
+	//   inject(chrome.runtime.getURL("installHook.js"), "script");
+	//
+	// The only solution so far is to set script.textContent directly. For
+	// that we need to do some custom bundling logic to store the content of
+	// installHook.ts in a variable.
+	//
+	// See: https://github.com/preactjs/preact-devtools/issues/85
+	//
+	// The string "CODE_TO_INJECT" will be replaced by our build tool.
+	inject(`;(${"CODE_TO_INJECT"}(window))`, "code");
 	injectStyles(chrome.runtime.getURL("installHook.css"));
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,8 +1,39 @@
 const archiver = require("archiver");
 const fs = require("fs");
+const path = require("path");
+const rimraf = require("rimraf");
 
 const browser = process.env.BROWSER;
 
+// Manually bundle injection code to make sure it runs before everything else
+const source = path.join(__dirname, "..", "dist", browser, "installHook.js");
+const target = path.join(__dirname, "..", "dist", browser, "initClient.js");
+const hook = fs
+	.readFileSync(source, "utf8")
+	.replace(/\(function \(\) \{/g, "function install() {")
+	.replace(/\}\(\)\);/g, "}");
+
+let targetFile = fs
+	.readFileSync(target, "utf8")
+	.replace(/\(function \(\) \{/g, "")
+	.replace(/\}\(\)\);/g, "")
+	.replace(/\}\(\)\);/g, "")
+	.replace(/"use\sstrict";/g, "")
+	.replace(/['"]CODE_TO_INJECT['"]/g, "installHook.toString()");
+
+targetFile = `;(function () {
+	"use strict";
+
+	let installHook = ${hook}
+	
+	${targetFile}
+}());`;
+fs.writeFileSync(target, targetFile);
+
+// Now that we inlined installHook.js we can delete it
+fs.unlinkSync(source);
+
+// Package extension
 const output = fs.createWriteStream(__dirname + `/../dist/${browser}.zip`);
 const archive = archiver("zip", { zlib: { level: 9 } });
 


### PR DESCRIPTION
The only reliable way to ensure that injected code is run before the page's js is by setting the script tag's `textContent` directly insteadof setting the "src"-attribute. Using the `src` attribute will lead to a race condition between our script tag and the page's js.

Fixes #85 .

