### PR TITLE
Fix inspect picker not working anymore

### DIFF
--- a/src/adapter/adapter/picker.ts
+++ b/src/adapter/adapter/picker.ts
@@ -8,22 +8,33 @@ export function createPicker(
 ) {
 	let picking = false;
 
-	function clicker() {
+	function clicker(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
 		stop();
 	}
 
 	function listener(e: WindowEventMap["mouseover"]) {
-		if (e.target != null) {
+		e.preventDefault();
+		e.stopPropagation();
+		if (picking && e.target != null) {
 			const id = renderer.findVNodeIdForDom(e.target as any);
 			if (id > -1) highlight(id);
 		}
 	}
 
+	function onMouseEvent(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+	}
+
 	function start() {
 		if (!picking) {
 			picking = true;
-			window.addEventListener("mouseover", listener);
-			window.addEventListener("click", clicker);
+			window.addEventListener("mousedown", onMouseEvent, true);
+			window.addEventListener("mouseover", listener, true);
+			window.addEventListener("mouseup", onMouseEvent, true);
+			window.addEventListener("click", clicker, true);
 		}
 	}
 
@@ -31,8 +42,11 @@ export function createPicker(
 		if (picking) {
 			picking = false;
 			onStop();
-			window.removeEventListener("mouseover", listener);
-			window.removeEventListener("click", clicker);
+
+			window.removeEventListener("mousedown", onMouseEvent, true);
+			window.removeEventListener("mouseover", listener, true);
+			window.removeEventListener("mouseup", onMouseEvent, true);
+			window.removeEventListener("click", clicker, true);
 		}
 	}
 

--- a/src/adapter/events/events.ts
+++ b/src/adapter/events/events.ts
@@ -142,7 +142,7 @@ export function applyEvent(store: Store, type: string, data: any) {
 			store.selection.selectById(data);
 			break;
 		case "stop-picker":
-			store.actions.stopPickElement();
+			store.isPicking.$ = false;
 			break;
 	}
 }

--- a/src/view/components/IconBtn.tsx
+++ b/src/view/components/IconBtn.tsx
@@ -10,6 +10,7 @@ export interface IconBtnProps {
 	onClick?: () => void;
 	styling?: "secondary" | "primary";
 	children: ComponentChildren;
+	testId?: string;
 }
 
 export function IconBtn(props: IconBtnProps) {
@@ -20,6 +21,7 @@ export function IconBtn(props: IconBtnProps) {
 			data-active={props.active}
 			title={props.title}
 			disabled={props.disabled}
+			data-testid={props.testId}
 			onClick={e => {
 				e.stopPropagation();
 				if (props.onClick) props.onClick();

--- a/src/view/components/elements/TreeBar.tsx
+++ b/src/view/components/elements/TreeBar.tsx
@@ -45,6 +45,7 @@ export function TreeBar() {
 				<IconBtn
 					active={isPicking}
 					title="Pick a Component from the page"
+					testId="inspect-btn"
 					onClick={() => {
 						if (!isPicking) store.actions.startPickElement();
 						else store.actions.stopPickElement();

--- a/test-e2e/test-utils.ts
+++ b/test-e2e/test-utils.ts
@@ -92,3 +92,7 @@ export async function typeText(page: Page, selector: string, text: string) {
 	await input.click({ clickCount: 3 });
 	return page.type(selector, text);
 }
+
+export async function getLog(page: Page) {
+	return (await page.evaluate(() => (window as any).log)) as any[];
+}

--- a/test-e2e/tests/inspect-click.test.ts
+++ b/test-e2e/tests/inspect-click.test.ts
@@ -1,0 +1,22 @@
+import { newTestPage, click, getLog, getText } from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pintf/browser_utils";
+
+export const description = "Don't trigger events on click during inspection";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "counter");
+
+	const target = '[data-testid="result"]';
+	expect(await getText(page, target)).to.equal("Counter: 0");
+
+	const inspect = '[data-testid="inspect-btn"]';
+	await click(devtools, inspect);
+
+	await page.click("button");
+
+	const text = await getText(page, target);
+	expect(text).to.equal("Counter: 0");
+
+	await closePage(page);
+}

--- a/test-e2e/tests/inspect.test.ts
+++ b/test-e2e/tests/inspect.test.ts
@@ -1,0 +1,32 @@
+import { newTestPage, click, getLog, getText } from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pintf/browser_utils";
+import { wait } from "pintf/utils";
+
+export const description = "Inspect should select node in elements panel";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "counter");
+
+	const inspect = '[data-testid="inspect-btn"]';
+	await click(devtools, inspect);
+
+	const target = '[data-testid="result"]';
+	await page.hover(target);
+
+	// Wait for possible flickering to occur
+	await wait(1000);
+
+	await page.click(target);
+
+	// Wait for possible flickering to occur
+	await wait(1000);
+
+	const log = await getLog(page);
+	expect(log.filter(x => x.type === "start-picker").length).to.equal(1);
+	expect(log.filter(x => x.type === "stop-picker").length).to.equal(1);
+
+	const text = await getText(devtools, '[data-selected="true"]');
+	expect(text).to.equal("Display");
+	await closePage(page);
+}


### PR DESCRIPTION
Thanks to the new e2e test framework this was quite easy to debug and fix :tada: 

- Fix Infinite loop by triggering the same event again
- Fix don't trigger any app events when the picker is active