### PR TITLE
Refactor inspection to be less error prone

### DIFF
--- a/src/adapter/adapter/adapter.ts
+++ b/src/adapter/adapter/adapter.ts
@@ -40,11 +40,21 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 
 	const highlight = createHightlighter(renderer);
 
+	const inspect = (id: ID) => {
+		if (renderer.has(id)) {
+			const data = renderer.inspect(id);
+			if (data) {
+				send("inspect-result", data);
+			}
+		}
+	};
+
 	const picker = createPicker(
 		window,
 		renderer,
 		id => {
 			highlight.highlight(id);
+			inspect(id);
 			send("select-node", id);
 		},
 		() => {
@@ -65,14 +75,7 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 		}
 	});
 
-	listen("inspect", id => {
-		if (renderer.has(id)) {
-			const data = renderer.inspect(id);
-			if (data) {
-				send("inspect-result", data);
-			}
-		}
-	});
+	listen("inspect", id => inspect(id));
 
 	listen("log", e => {
 		if (renderer.has(e.id)) {
@@ -96,12 +99,7 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 		renderer.update(id, type, path, value);
 
 		// Notify all frontends that something changed
-		if (renderer.has(id)) {
-			const data = renderer.inspect(id);
-			if (data !== null) {
-				send("inspect-result", data);
-			}
-		}
+		inspect(id);
 	};
 
 	listen("update-prop", data => update({ ...data, type: "props" }));

--- a/src/adapter/adapter/picker.ts
+++ b/src/adapter/adapter/picker.ts
@@ -3,10 +3,11 @@ import { Renderer } from "../renderer";
 export function createPicker(
 	window: Window,
 	renderer: Renderer,
-	highlight: (id: number) => void,
+	onHover: (id: number) => void,
 	onStop: () => void,
 ) {
 	let picking = false;
+	let lastId = -1;
 
 	function clicker(e: MouseEvent) {
 		e.preventDefault();
@@ -19,7 +20,10 @@ export function createPicker(
 		e.stopPropagation();
 		if (picking && e.target != null) {
 			const id = renderer.findVNodeIdForDom(e.target as any);
-			if (id > -1) highlight(id);
+			if (id > -1 && lastId !== id) {
+				onHover(id);
+			}
+			lastId = id;
 		}
 	}
 
@@ -30,6 +34,7 @@ export function createPicker(
 
 	function start() {
 		if (!picking) {
+			lastId = -1;
 			picking = true;
 			window.addEventListener("mousedown", onMouseEvent, true);
 			window.addEventListener("mouseover", listener, true);
@@ -40,6 +45,7 @@ export function createPicker(
 
 	function stop() {
 		if (picking) {
+			lastId = -1;
 			picking = false;
 			onStop();
 

--- a/src/view/components/elements/TreeView.tsx
+++ b/src/view/components/elements/TreeView.tsx
@@ -28,8 +28,16 @@ export function TreeView() {
 			return node ? node.children.length > 0 : false;
 		},
 		checkCollapsed: id => collapsed.has(id),
-		onNext: selectNext,
-		onPrev: selectPrev,
+		onNext: () => {
+			selectNext();
+			store.actions.highlightNode(store.selection.selected.$);
+			store.actions.inspect(store.selection.selected.$);
+		},
+		onPrev: () => {
+			selectPrev();
+			store.actions.highlightNode(store.selection.selected.$);
+			store.actions.inspect(store.selection.selected.$);
+		},
 	});
 
 	const onMouseLeave = useCallback(() => store.actions.highlightNode(null), []);
@@ -146,7 +154,10 @@ export function TreeItem(props: { key: any; id: ID }) {
 			class={s.item}
 			data-testid="tree-item"
 			data-name={node.name}
-			onClick={() => sel.selectById(id)}
+			onClick={() => {
+				sel.selectById(id);
+				store.actions.inspect(id);
+			}}
 			onMouseEnter={() => store.actions.highlightNode(id)}
 			data-selected={isSelected}
 			data-id={id}

--- a/src/view/store/index.ts
+++ b/src/view/store/index.ts
@@ -54,15 +54,6 @@ export function createStore(): Store {
 	const inspectData = valoo<InspectData | null>(null);
 	const selection = createSelectionStore(nodeList);
 
-	// Update inspect data on selection
-	selection.selected.on(id => {
-		if (id > -1) {
-			notify("inspect", id);
-		} else {
-			inspectData.$ = null;
-		}
-	});
-
 	return {
 		profiler: createProfiler(),
 		nodeList,

--- a/test-e2e/tests/element-keyboard.test.ts
+++ b/test-e2e/tests/element-keyboard.test.ts
@@ -1,0 +1,33 @@
+import { newTestPage, getText } from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pintf/browser_utils";
+import { wait } from "pintf/utils";
+
+export const description = "Test keyboard navigation in elements tree";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "counter");
+
+	const elem1 = '[data-testid="tree-item"][data-name="Counter"]';
+	const prop = '[data-testid="props-row"]';
+
+	await devtools.click(elem1);
+	await wait(500);
+	expect((await devtools.$$(prop)).length).to.equal(0);
+
+	await page.keyboard.press("ArrowDown");
+	await wait(500);
+	let selected = await getText(devtools, '[data-selected="true"]');
+
+	expect(selected).to.equal("Display");
+	expect((await devtools.$$(prop)).length).to.equal(1);
+
+	await page.keyboard.press("ArrowUp");
+	await wait(500);
+	selected = await getText(devtools, '[data-selected="true"]');
+
+	expect(selected).to.equal("Counter");
+	expect((await devtools.$$(prop)).length).to.equal(0);
+
+	await closePage(page);
+}

--- a/test-e2e/tests/inspect-select.test.ts
+++ b/test-e2e/tests/inspect-select.test.ts
@@ -1,0 +1,57 @@
+import {
+	newTestPage,
+	getText,
+	getLog,
+	getAttribute,
+	getSize,
+} from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pintf/browser_utils";
+import { wait } from "pintf/utils";
+
+export const description = "Should inspect during picking";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "counter");
+
+	const elem1 = '[data-testid="tree-item"][data-name="Counter"]';
+	const prop = '[data-testid="props-row"]';
+	await devtools.click(elem1);
+	await wait(500);
+	expect((await devtools.$$(prop)).length).to.equal(0);
+
+	const target = '[data-testid="result"]';
+	const inspect = '[data-testid="inspect-btn"]';
+
+	await devtools.click(inspect);
+	let active = await getAttribute(devtools, inspect, "data-active");
+	expect(active).to.equal("true");
+
+	await page.hover(target);
+	await wait(100);
+
+	// Move mouse slightly
+	const rect = await getSize(page, target);
+	await page.mouse.move(rect.x, rect.y);
+	await wait(500);
+
+	// Should load prop data
+	expect((await devtools.$$(prop)).length).to.equal(1);
+
+	// Should only fire inspect event once per id
+	const inspects = (await getLog(page)).filter(
+		x => x.type === "inspect-result",
+	);
+	expect(inspects.length).to.equal(2);
+
+	// Should select new node in element tree
+	await page.click(target);
+	await wait(500);
+	active = await getAttribute(devtools, inspect, "data-active");
+	expect(active).to.equal(null);
+
+	// ...and display the newly inspected data
+	expect((await devtools.$$(prop)).length).to.equal(1);
+
+	await closePage(page);
+}


### PR DESCRIPTION
Refactor the inspection picker code to be less error prone. By making it more push-oriented some errors are automatically resolved like a case where we could run into an infinite loop.

- Fix infinite loop when new inspection finished
- Feature: Inspect during picking
- Fix keyboard navigation not loading inspect data