### PR TITLE
Only display nodes of the current commit in ranked view

### DIFF
--- a/src/view/components/profiler/components/TimelineBar/TimelineBar.tsx
+++ b/src/view/components/profiler/components/TimelineBar/TimelineBar.tsx
@@ -87,6 +87,7 @@ export function RecordBtn() {
 			}
 			onClick={onClick}
 			disabled={!isSupported}
+			testId="record-btn"
 		>
 			<RecordIcon size="s" />
 		</IconBtn>

--- a/src/view/components/profiler/flamegraph/FlamegraphStore.ts
+++ b/src/view/components/profiler/flamegraph/FlamegraphStore.ts
@@ -35,7 +35,14 @@ export function createFlameGraphStore(profiler: ProfilerState) {
 		const viewMode = profiler.flamegraphType.$;
 		let nodes: NodeTransform[] = [];
 		if (viewMode === FlamegraphType.RANKED) {
-			nodes = layoutRanked(items);
+			const root = commit.nodes.get(commit.commitRootId)!;
+			nodes = layoutRanked(
+				items.filter(node => {
+					return (
+						node.startTime >= root.startTime && node.endTime <= root.endTime
+					);
+				}),
+			);
 		} else if (viewMode === FlamegraphType.FLAMEGRAPH) {
 			nodes = layoutTimeline(items);
 

--- a/test-e2e/test-utils.ts
+++ b/test-e2e/test-utils.ts
@@ -100,9 +100,38 @@ export async function getText(page: Page, selector: string) {
 	return getAttribute(page, selector, "textContent");
 }
 
+export async function waitForAttribute(
+	page: Page,
+	selector: string,
+	name: string,
+	value: string | number | null | undefined | RegExp,
+	options: any = {},
+) {
+	await page.waitForFunction(
+		(s, n, v) => {
+			const el = document.querySelector(s);
+			if (el === null) return false;
+			const attr = n in el ? (el as any)[n] : el.getAttribute(n);
+			if (typeof v === "object" && v !== null && v.type === "regex") {
+				return new RegExp(v.source, v.flags).test(attr);
+			}
+
+			return attr === v;
+		},
+		{ timeout: 3000, ...options },
+		selector,
+		name,
+		value instanceof RegExp
+			? { type: "regex", source: value.source, flags: value.flags }
+			: value === undefined
+			? null
+			: value,
+	);
+}
+
 export async function click(page: Page, selector: string) {
 	await page.waitForSelector(selector);
-	return page.$eval(selector, (el: any) => el.click());
+	return page.click(selector);
 }
 
 export async function typeText(page: Page, selector: string, text: string) {

--- a/test-e2e/tests/fixtures/profiler-1.js
+++ b/test-e2e/tests/fixtures/profiler-1.js
@@ -1,0 +1,34 @@
+const { h, render } = preact;
+const { useState } = preactHooks;
+
+function Display(props) {
+	return html`
+		<div data-testid="result">Counter: ${props.value}</div>
+	`;
+}
+
+function Counter() {
+	const [v, set] = useState(0);
+
+	return html`
+		<div style="padding: 2rem;">
+			<${Display} value=${v} />
+			<button onClick=${() => set(v + 1)}>Increment</button>
+		</div>
+	`;
+}
+
+function Foo() {
+	return html`
+		<div>foo</div>
+	`;
+}
+
+function App() {
+	return html`
+		<${Counter} />
+		<${Foo} />
+	`;
+}
+
+render(h(App), document.getElementById("app"));

--- a/test-e2e/tests/profiler-ranked.test.ts
+++ b/test-e2e/tests/profiler-ranked.test.ts
@@ -1,0 +1,30 @@
+import { newTestPage, click, waitForAttribute } from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pintf/browser_utils";
+
+export const description =
+	"Ranked profile view should only show nodes of the current commit";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "profiler-1");
+
+	await click(devtools, '[name="root-panel"][value="PROFILER"]');
+	await click(devtools, '[name="flamegraph_mode"][value="RANKED"]');
+
+	const recordBtn = '[data-testid="record-btn"]';
+	await click(devtools, recordBtn);
+
+	await waitForAttribute(devtools, recordBtn, "title", /Stop Recording/);
+
+	await click(page, "button");
+	await click(page, "button");
+
+	await click(devtools, recordBtn);
+
+	const nodes = await devtools.$$(
+		'[data-type="ranked"] > *:not([data-weight])',
+	);
+	expect(nodes.length).to.equal(0);
+
+	await closePage(page);
+}


### PR DESCRIPTION
Basically this means that the gray nodes are not visible when in `ranked` mode in the profiler.