### PR TITLE
Fix updates mutating existing vnode properties

### DIFF
--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -13,10 +13,11 @@ import {
 	getActualChildren,
 	getVNodeParent,
 	hasDom,
+	setNextState,
 } from "./vnode";
 import { shouldFilter } from "./filter";
 import { ID } from "../../view/store/types";
-import { traverse, setIn, SerializedVNode } from "./utils";
+import { traverse, setIn, SerializedVNode, setInCopy } from "./utils";
 import { FilterState } from "../adapter/filter";
 import { Renderer, Elements } from "../renderer";
 import {
@@ -243,10 +244,21 @@ export function createRenderer(
 					const c = getComponent(vnode);
 					if (c) {
 						if (type === "props") {
-							setIn((vnode.props as any) || {}, path.slice(), value);
+							vnode.props = setInCopy(
+								(vnode.props as any) || {},
+								path.slice(),
+								value,
+							);
 						} else if (type === "state") {
-							setIn((c.state as any) || {}, path.slice(), value);
+							const res = setInCopy(
+								(c.state as any) || {},
+								path.slice(),
+								value,
+							);
+							setNextState(c, res);
 						} else if (type === "context") {
+							// TODO: Investigate if we should disallow modifying context
+							// from devtools and make it readonly.
 							setIn((c.context as any) || {}, path.slice(), value);
 						}
 

--- a/src/adapter/10/utils.test.tsx
+++ b/src/adapter/10/utils.test.tsx
@@ -2,7 +2,7 @@ import { h, Component, createContext, render } from "preact";
 import { teardown } from "preact/test-utils";
 import { setupScratch } from "./renderer.test";
 import { expect } from "chai";
-import { cleanContext, cleanProps, jsonify } from "./utils";
+import { cleanContext, cleanProps, jsonify, setInCopy } from "./utils";
 import { getActualChildren } from "./vnode";
 
 describe("cleanContext", () => {
@@ -116,5 +116,27 @@ describe("jsonify", () => {
 			foo: 123,
 			bar: { foo: 123 },
 		});
+	});
+});
+
+describe("setInCopy", () => {
+	it("should update arrays", () => {
+		const obj = { foo: [1] };
+		const res = setInCopy(obj, ["foo", 0], 2);
+		expect(res).to.deep.equal({
+			foo: [2],
+		});
+		expect(res).not.equal(obj);
+		expect(res.foo).not.equal(obj.foo);
+	});
+
+	it("should not mutate existing object", () => {
+		const obj = { foo: { bar: 1 } };
+		const res = setInCopy(obj, ["foo", "bar"], 2);
+		expect(res).to.deep.equal({
+			foo: { bar: 2 },
+		});
+		expect(res).not.equal(obj);
+		expect(res.foo).not.equal(obj.foo);
 	});
 });

--- a/src/adapter/10/utils.ts
+++ b/src/adapter/10/utils.ts
@@ -92,6 +92,23 @@ export function cleanContext(context: Record<string, any>) {
 }
 
 /**
+ * Deeply set a property and clone all parent objects/arrays
+ */
+export function setInCopy<T = any>(
+	obj: T,
+	path: ObjPath,
+	value: any,
+	idx = 0,
+): T {
+	if (idx >= path.length) return value;
+
+	const updated = Array.isArray(obj) ? obj.slice() : { ...obj };
+	const key = path[idx];
+	(updated as any)[key] = setInCopy((obj as any)[key], path, value, idx + 1);
+	return updated as any;
+}
+
+/**
  * Deeply mutate a property by walking down an array of property keys
  */
 export function setIn(obj: Record<string, any>, path: ObjPath, value: any) {

--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -119,3 +119,7 @@ export function getEndTime(vnode: VNode) {
 export function getStartTime(vnode: VNode) {
 	return vnode.startTime || 0;
 }
+
+export function setNextState(c: Component, value: any) {
+	(c as any)._nextState = (c as any).__s = value;
+}

--- a/test-e2e/tests/fixtures/update-all.js
+++ b/test-e2e/tests/fixtures/update-all.js
@@ -54,14 +54,11 @@ function Context() {
 
 let lastLegacyContext;
 function LegacyConsumer(_, context) {
-	const out = html`
+	return html`
 		<div data-testid="legacy-context-result">
-			legacy context: ${context.value}, ${String(lastLegacyContext !== context)}
+			legacy context: ${context.value}
 		</div>
 	`;
-
-	lastLegacyContext = context;
-	return out;
 }
 
 class LegacyContext extends Component {

--- a/test-e2e/tests/fixtures/update-all.js
+++ b/test-e2e/tests/fixtures/update-all.js
@@ -1,0 +1,88 @@
+const { h, render, Component, createContext } = preact;
+
+let lastState;
+class State extends Component {
+	state = {
+		value: 0,
+	};
+
+	render() {
+		const out = html`
+			<div data-testid="state-result">
+				state: ${this.state.value}, ${String(lastState !== this.state)}
+			</div>
+		`;
+
+		lastState = this.state;
+		return out;
+	}
+}
+
+let lastProps;
+function Props(props) {
+	const out = html`
+		<div data-testid="props-result">
+			props: ${props.value}, ${String(lastProps !== props)}
+		</div>
+	`;
+
+	lastProps = props;
+	return out;
+}
+
+const Ctx = createContext({ value: 0 });
+
+let lastContext;
+function Context() {
+	return html`
+		<${Ctx.Provider} value="${{ value: 0 }}">
+			<${Ctx.Consumer}>
+				${v => {
+					const out = html`
+						<div data-testid="context-result">
+							context: ${v.value}, ${String(v !== lastContext)}
+						</div>
+					`;
+
+					lastContext = v;
+					return out;
+				}}
+			<//>
+		<//>
+	`;
+}
+
+let lastLegacyContext;
+function LegacyConsumer(_, context) {
+	const out = html`
+		<div data-testid="legacy-context-result">
+			legacy context: ${context.value}, ${String(lastLegacyContext !== context)}
+		</div>
+	`;
+
+	lastLegacyContext = context;
+	return out;
+}
+
+class LegacyContext extends Component {
+	getChildContext() {
+		return { value: 0 };
+	}
+
+	render() {
+		return html`
+			<${LegacyConsumer} />
+		`;
+	}
+}
+
+function App() {
+	return html`
+		<${Props} value=${0} />
+		<${State} />
+		<${Context} />
+		<${LegacyContext} />
+	`;
+}
+
+render(h(App), document.getElementById("app"));

--- a/test-e2e/tests/update-copy.test.ts
+++ b/test-e2e/tests/update-copy.test.ts
@@ -1,5 +1,5 @@
 import { newTestPage, typeText } from "../test-utils";
-import { clickText, closePage, waitForText } from "pintf/browser_utils";
+import { clickText, closePage } from "pintf/browser_utils";
 import { Page } from "puppeteer";
 
 async function type(page: Page, devtools: Page, value: string | number) {
@@ -8,6 +8,18 @@ async function type(page: Page, devtools: Page, value: string | number) {
 
 	await typeText(devtools, input, String(value));
 	await page.keyboard.press("Enter");
+}
+
+async function waitForResult(page: Page, selector: string, value: string) {
+	await page.waitForFunction(
+		(s, v) => {
+			const el = document.querySelector(`[data-testid="${s}"]`);
+			return el !== null ? el.textContent === v : false;
+		},
+		{ timeout: 1000 },
+		selector,
+		value,
+	);
 }
 
 export const description =
@@ -19,17 +31,17 @@ export async function run(config: any) {
 	// Props
 	await clickText(devtools, "Props", { elementXPath: "//*" });
 	await type(page, devtools, "1");
-	await waitForText(page, "props: 1, true", { timeout: 1000 });
+	await waitForResult(page, "props-result", "props: 1, true");
 
 	// State
 	await clickText(devtools, "State", { elementXPath: "//*" });
 	await type(page, devtools, "1");
-	await waitForText(page, "state: 1, true", { timeout: 1000 });
+	await waitForResult(page, "state-result", "state: 1, true");
 
 	// Legacy Context
 	await clickText(devtools, "LegacyConsumer", { elementXPath: "//*" });
 	await type(page, devtools, "1");
-	await waitForText(page, "legacy context: 1, true", { timeout: 1000 });
+	await waitForResult(page, "legacy-context-result", "legacy context: 1");
 
 	await closePage(page);
 }

--- a/test-e2e/tests/update-copy.test.ts
+++ b/test-e2e/tests/update-copy.test.ts
@@ -1,0 +1,35 @@
+import { newTestPage, typeText } from "../test-utils";
+import { clickText, closePage, waitForText } from "pintf/browser_utils";
+import { Page } from "puppeteer";
+
+async function type(page: Page, devtools: Page, value: string | number) {
+	const input = '[data-testid="prop-value"] input';
+	await devtools.waitForSelector(input);
+
+	await typeText(devtools, input, String(value));
+	await page.keyboard.press("Enter");
+}
+
+export const description =
+	"Create a copy when doing props/state/context updates";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "update-all");
+
+	// Props
+	await clickText(devtools, "Props", { elementXPath: "//*" });
+	await type(page, devtools, "1");
+	await waitForText(page, "props: 1, true", { timeout: 1000 });
+
+	// State
+	await clickText(devtools, "State", { elementXPath: "//*" });
+	await type(page, devtools, "1");
+	await waitForText(page, "state: 1, true", { timeout: 1000 });
+
+	// Legacy Context
+	await clickText(devtools, "LegacyConsumer", { elementXPath: "//*" });
+	await type(page, devtools, "1");
+	await waitForText(page, "legacy context: 1, true", { timeout: 1000 });
+
+	await closePage(page);
+}


### PR DESCRIPTION
Updates should never mutate props/state/context but instead create a new object.

Tasks:

- [x] Add test case
- [x] Fix bug

Fixes #118 .