### PR TITLE
Add support for user timings API

### DIFF
--- a/src/adapter/10/marks.ts
+++ b/src/adapter/10/marks.ts
@@ -4,19 +4,27 @@
 
 const markName = (s: string) => `⚛ ${s}`;
 
+const supportsPerformance =
+	globalThis.performance &&
+	typeof globalThis.performance.getEntriesByName === "function";
+
 export function recordMark(s: string) {
-	performance.mark(markName(s));
+	if (supportsPerformance) {
+		performance.mark(markName(s));
+	}
 }
 
 export function endMark(nodeName: string) {
-	const name = markName(nodeName);
-	const start = `${name}_diff`;
-	const end = `${name}_diffed`;
-	if (performance.getEntriesByName(start).length > 0) {
-		performance.mark(end);
-		performance.measure(name, start, end);
+	if (supportsPerformance) {
+		const name = markName(nodeName);
+		const start = `${name}_diff`;
+		const end = `${name}_diffed`;
+		if (performance.getEntriesByName(start).length > 0) {
+			performance.mark(end);
+			performance.measure(name, start, end);
+		}
+		performance.clearMarks(start);
+		performance.clearMarks(end);
+		performance.clearMeasures(name);
 	}
-	performance.clearMarks(start);
-	performance.clearMarks(end);
-	performance.clearMeasures(name);
 }

--- a/src/adapter/10/marks.ts
+++ b/src/adapter/10/marks.ts
@@ -1,0 +1,22 @@
+// Here we use the "User Timing API" to collect samples for the
+// native profiling tools of browsers. These timings will show
+// up in the "Timing" category.
+
+const markName = (s: string) => `⚛ ${s}`;
+
+export function recordMark(s: string) {
+	performance.mark(markName(s));
+}
+
+export function endMark(nodeName: string) {
+	const name = markName(nodeName);
+	const start = `${name}_diff`;
+	const end = `${name}_diffed`;
+	if (performance.getEntriesByName(start).length > 0) {
+		performance.mark(end);
+		performance.measure(name, start, end);
+	}
+	performance.clearMarks(start);
+	performance.clearMarks(end);
+	performance.clearMeasures(name);
+}

--- a/src/adapter/10/options.ts
+++ b/src/adapter/10/options.ts
@@ -1,7 +1,13 @@
 import { Options, VNode } from "preact";
-import { Preact10Renderer } from "./renderer";
+import { Preact10Renderer, RendererConfig10 } from "./renderer";
+import { recordMark, endMark } from "./marks";
+import { getDisplayName } from "./vnode";
 
-export function setupOptions(options: Options, renderer: Preact10Renderer) {
+export function setupOptions(
+	options: Options,
+	renderer: Preact10Renderer,
+	config: RendererConfig10,
+) {
 	const o = options as any;
 
 	// Store (possible) previous hooks so that we don't overwrite them
@@ -28,11 +34,21 @@ export function setupOptions(options: Options, renderer: Preact10Renderer) {
 
 	o._diff = o.__b = (vnode: VNode) => {
 		vnode.startTime = performance.now();
+
+		if (typeof vnode.type === "function") {
+			const name = getDisplayName(vnode, config);
+			recordMark(`${name}_diff`);
+		}
+
 		if (prevBeforeDiff != null) prevBeforeDiff(vnode);
 	};
 
 	options.diffed = vnode => {
 		vnode.endTime = performance.now();
+
+		if (typeof vnode.type === "function") {
+			endMark(getDisplayName(vnode, config));
+		}
 
 		if (prevAfterDiff) prevAfterDiff(vnode);
 	};

--- a/src/adapter/10/renderer.test.tsx
+++ b/src/adapter/10/renderer.test.tsx
@@ -25,7 +25,9 @@ export function setupMockHook(options: Options) {
 		{ Fragment: Fragment as any },
 		{ type: new Set(), regex: [] },
 	);
-	const destroy = setupOptions(options, renderer);
+	const destroy = setupOptions(options, renderer, {
+		Fragment: Fragment as any,
+	});
 	return {
 		renderer,
 		destroy,

--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -133,7 +133,7 @@ export function createHook(port: PortPageHook): DevtoolsHook {
 			// currently we only support preact >= 10, later we can add another branch for major === 8
 			if (preactVersionMatch.major == 10) {
 				const renderer = createRenderer(port, config as any);
-				setupOptions(options, renderer);
+				setupOptions(options, renderer, config as any);
 				return attachRenderer(renderer);
 			}
 

--- a/src/view/components/sidebar/inspect/ElementProps.tsx
+++ b/src/view/components/sidebar/inspect/ElementProps.tsx
@@ -28,7 +28,6 @@ export function ElementProps(props: Props) {
 			<form class={s.form} onSubmit={e => e.preventDefault()}>
 				{items.map(item => {
 					const id = item.id;
-					console.log(item);
 					return (
 						<SingleItem
 							id={nodeId}


### PR DESCRIPTION
This PR collects performance timings for Chrome's native profiling tools. Currently this only works in Chrome and probably Edge. Haven't found a way to show them in Firefox.

This will measure the time it takes from `options._diff` to `options._diff`

![Screenshot from 2020-04-11 09-11-49](https://user-images.githubusercontent.com/1062408/79037798-8998d800-7bd4-11ea-898f-1200e3b33893.png)

Fixes #73 .