### PR TITLE
Minor props parser refactoring

### DIFF
--- a/src/adapter/10/utils.ts
+++ b/src/adapter/10/utils.ts
@@ -1,6 +1,6 @@
 import { getActualChildren } from "./vnode";
 import { VNode } from "preact";
-import { ObjPath } from "../../view/components/sidebar/inspect/ElementProps";
+import { ObjPath } from "../renderer";
 
 export function traverse(vnode: VNode, fn: (vnode: VNode) => void) {
 	fn(vnode);

--- a/src/adapter/adapter/adapter.ts
+++ b/src/adapter/adapter/adapter.ts
@@ -96,7 +96,7 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 
 	const update = (data: DevtoolEvents["update"]) => {
 		const { id, type, path, value } = data;
-		renderer.update(id, type, path, value);
+		renderer.update(id, type, path.split(".").slice(1), value);
 
 		// Notify all frontends that something changed
 		inspect(id);

--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -1,5 +1,4 @@
 import { Renderer } from "./renderer";
-import { ObjPath } from "../view/components/sidebar/inspect/ElementProps";
 import { ID } from "../view/store/types";
 import { createAdapter, InspectData, UpdateType } from "./adapter/adapter";
 import { RawFilterState } from "./adapter/filter";
@@ -13,9 +12,9 @@ import { PortPageHook } from "./adapter/port";
 export type EmitterFn = (event: string, data: any) => void;
 
 export interface DevtoolEvents {
-	"update-prop": { id: ID; path: ObjPath; value: any };
-	"update-state": { id: ID; path: ObjPath; value: any };
-	"update-context": { id: ID; path: ObjPath; value: any };
+	"update-prop": { id: ID; path: string; value: any };
+	"update-state": { id: ID; path: string; value: any };
+	"update-context": { id: ID; path: string; value: any };
 	"force-update": ID;
 	"start-picker": null;
 	"stop-picker": null;
@@ -28,7 +27,7 @@ export interface DevtoolEvents {
 	log: { id: ID; children: ID[] };
 	inspect: ID;
 	"select-node": ID;
-	update: { id: ID; type: UpdateType; path: ObjPath; value: any };
+	update: { id: ID; type: UpdateType; path: string; value: any };
 	"inspect-result": InspectData;
 	attach: { id: ID; supportsProfiling: boolean };
 	initialized: null;

--- a/src/adapter/renderer.ts
+++ b/src/adapter/renderer.ts
@@ -2,8 +2,9 @@ import { VNode } from "preact";
 import { ID } from "../view/store/types";
 import { FilterState } from "./adapter/filter";
 import { InspectData, UpdateType } from "./adapter/adapter";
-import { ObjPath } from "../view/components/sidebar/inspect/ElementProps";
 import { DevtoolEvents } from "./hook";
+
+export type ObjPath = Array<string | number>;
 
 /**
  * TODO: Deprecate this

--- a/src/view/components/sidebar/inspect/ElementProps.tsx
+++ b/src/view/components/sidebar/inspect/ElementProps.tsx
@@ -4,15 +4,12 @@ import { Arrow } from "../../elements/TreeView";
 import { PropDataType, PropData } from "./parseProps";
 import { DataInput } from "../../DataInput";
 import { genPreview } from "../../DataInput/parseValue";
-import { ID } from "../../../store/types";
 import { Observable } from "../../../valoo";
 import { isCollapsed } from "../../../store/props";
 
-export type ObjPath = Array<string | number>;
-export type ChangeFn = (value: any, path: ObjPath) => void;
+export type ChangeFn = (value: any, path: string) => void;
 
 export interface Props {
-	nodeId: ID;
 	editable?: boolean;
 	onChange?: ChangeFn;
 	onCollapse?: (path: string) => void;
@@ -21,7 +18,7 @@ export interface Props {
 }
 
 export function ElementProps(props: Props) {
-	const { editable, onChange, uncollapsed, items, onCollapse, nodeId } = props;
+	const { editable, onChange, uncollapsed, items, onCollapse } = props;
 
 	return (
 		<div class={s.root}>
@@ -30,7 +27,7 @@ export function ElementProps(props: Props) {
 					const id = item.id;
 					return (
 						<SingleItem
-							id={nodeId}
+							id={id}
 							key={id}
 							type={item.type}
 							name={id.slice(id.lastIndexOf(".") + 1)}
@@ -39,7 +36,6 @@ export function ElementProps(props: Props) {
 							onCollapse={() => onCollapse && onCollapse(id)}
 							editable={editable && item.editable}
 							value={item.value}
-							path={item.path}
 							onChange={onChange}
 							depth={item.depth}
 						/>
@@ -51,17 +47,16 @@ export function ElementProps(props: Props) {
 }
 
 export interface SingleProps {
-	id: ID;
+	id: string;
 	key?: string;
 	editable?: boolean;
 	type: PropDataType;
 	collapseable?: boolean;
 	collapsed?: boolean;
-	path: ObjPath;
 	name: string;
 	value: any;
 	onChange?: ChangeFn;
-	onCollapse?: (path: ObjPath) => void;
+	onCollapse?: (path: string) => void;
 	depth: number;
 }
 
@@ -69,7 +64,6 @@ export function SingleItem(props: SingleProps) {
 	const {
 		id,
 		onChange,
-		path,
 		editable = false,
 		name,
 		type,
@@ -82,7 +76,7 @@ export function SingleItem(props: SingleProps) {
 
 	return (
 		<div
-			key={path.join(".")}
+			key={id}
 			class={s.row}
 			data-testid="props-row"
 			data-depth={depth}
@@ -93,7 +87,7 @@ export function SingleItem(props: SingleProps) {
 					class={s.toggle}
 					type="button"
 					data-collapsed={collapsed}
-					onClick={() => onCollapse && onCollapse(path)}
+					onClick={() => onCollapse && onCollapse(id)}
 				>
 					<Arrow />
 					<span class={s.name} data-type={type}>
@@ -118,8 +112,8 @@ export function SingleItem(props: SingleProps) {
 						{editable ? (
 							<DataInput
 								value={value}
-								onChange={v => onChange && onChange(v, path)}
-								name={`${id}#${path.join(".")}`}
+								onChange={v => onChange && onChange(v, id)}
+								name={`${id}`}
 							/>
 						) : (
 							<div class={s.mask}>{genPreview(value)}</div>

--- a/src/view/components/sidebar/inspect/NewProp.tsx
+++ b/src/view/components/sidebar/inspect/NewProp.tsx
@@ -3,10 +3,9 @@ import { useState, useCallback } from "preact/hooks";
 import { DataInput } from "../../DataInput";
 import s from "./NewProp.css";
 import s2 from "./ElementProps.css";
-import { ObjPath } from "./ElementProps";
 
 export interface NewPropProps {
-	onChange: (value: any, path: ObjPath) => void;
+	onChange: (value: any, path: string) => void;
 }
 
 export function NewProp(props: NewPropProps) {
@@ -19,8 +18,7 @@ export function NewProp(props: NewPropProps) {
 	const onCommit = useCallback(
 		(value: any) => {
 			if (name) {
-				const path = ["root", ...name.split(".").filter(Boolean)];
-				props.onChange(value, path);
+				props.onChange(value, name);
 				setName("");
 			}
 		},

--- a/src/view/components/sidebar/inspect/PropsPanel.tsx
+++ b/src/view/components/sidebar/inspect/PropsPanel.tsx
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { ElementProps, ObjPath } from "./ElementProps";
+import { ElementProps } from "./ElementProps";
 import { useStore, useObserver } from "../../../store/react-bindings";
 import { useCallback } from "preact/hooks";
 import { createPropsStore, toggleCollapsed } from "../../../store/props";
@@ -17,7 +17,7 @@ export interface Props {
 	checkEditable: (data: InspectData) => boolean;
 	getData(data: InspectData): any;
 	canAddNew?: boolean;
-	onChange: (id: ID, path: ObjPath, value: any) => void;
+	onChange: (id: ID, path: string, value: any) => void;
 	onCopy?: (data: any) => void;
 }
 
@@ -35,9 +35,8 @@ export function PropsPanel(props: Props) {
 	const items = useObserver(() => s.list.$);
 
 	const onChange = useCallback(
-		(value: any, path: ObjPath) => {
-			const key = path.slice(1);
-			props.onChange(inspect!.id, key, value);
+		(value: any, path: string) => {
+			props.onChange(inspect!.id, path, value);
 		},
 		[inspect],
 	);
@@ -59,7 +58,6 @@ export function PropsPanel(props: Props) {
 			}}
 		>
 			<ElementProps
-				nodeId={inspect.id}
 				editable={props.checkEditable(inspect)}
 				uncollapsed={s.uncollapsed}
 				items={items.map(x => s.tree.$.get(x)!)}

--- a/src/view/components/sidebar/inspect/parseProps.test.ts
+++ b/src/view/components/sidebar/inspect/parseProps.test.ts
@@ -3,12 +3,10 @@ import { parseProps } from "./parseProps";
 
 const serialize = (v: Map<any, any>) => Array.from(v.values());
 
-const noop = (v: any) => v;
-
 describe("flatten", () => {
 	it("should flatten strings", () => {
 		const tree = new Map();
-		parseProps("foo", ["foo"], 2, noop, tree);
+		parseProps("foo", ["foo"], 2, tree);
 
 		expect(serialize(tree)).to.deep.equal([
 			{
@@ -26,7 +24,7 @@ describe("flatten", () => {
 
 	it("should flatten numbers", () => {
 		const tree = new Map();
-		parseProps(12, ["foo"], 2, noop, tree);
+		parseProps(12, ["foo"], 2, tree);
 
 		expect(serialize(tree)).to.deep.equal([
 			{
@@ -44,7 +42,7 @@ describe("flatten", () => {
 
 	it("should flatten booleans", () => {
 		const tree = new Map();
-		parseProps(false, ["foo"], 2, noop, tree);
+		parseProps(false, ["foo"], 2, tree);
 
 		expect(serialize(tree)).to.deep.equal([
 			{
@@ -62,7 +60,7 @@ describe("flatten", () => {
 
 	it("should flatten null", () => {
 		const tree = new Map();
-		parseProps(null, ["foo"], 2, noop, tree);
+		parseProps(null, ["foo"], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
@@ -79,7 +77,7 @@ describe("flatten", () => {
 
 	it("should flatten undefined", () => {
 		const tree = new Map();
-		parseProps(undefined, ["foo"], 2, noop, tree);
+		parseProps(undefined, ["foo"], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
@@ -100,7 +98,7 @@ describe("flatten", () => {
 			type: "function",
 			name: "fooBar",
 		};
-		parseProps(fn, ["foo"], 2, noop, tree);
+		parseProps(fn, ["foo"], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
@@ -117,7 +115,7 @@ describe("flatten", () => {
 
 	it("should flatten arrays", () => {
 		const tree = new Map();
-		parseProps([1, 2], ["foo"], 2, noop, tree);
+		parseProps([1, 2], ["foo"], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
@@ -154,7 +152,7 @@ describe("flatten", () => {
 
 	it("should not mark empty arrays as collabsible", () => {
 		const tree = new Map();
-		parseProps([], ["foo"], 2, noop, tree);
+		parseProps([], ["foo"], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
@@ -171,7 +169,7 @@ describe("flatten", () => {
 
 	it("should flatten objects", () => {
 		const tree = new Map();
-		parseProps({ foo: 123, bar: "abc" }, [""], 2, noop, tree);
+		parseProps({ foo: 123, bar: "abc" }, [""], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
@@ -211,7 +209,7 @@ describe("flatten", () => {
 
 	it("should flatten nested objects", () => {
 		const tree = new Map();
-		parseProps({ foo: { bar: "abc" } }, ["foo"], 4, noop, tree);
+		parseProps({ foo: { bar: "abc" } }, ["foo"], 4, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
@@ -254,7 +252,7 @@ describe("flatten", () => {
 
 	it("should limit depth", () => {
 		const tree = new Map();
-		parseProps({ foo: { bar: "abc" } }, ["foo"], 2, noop, tree);
+		parseProps({ foo: { bar: "abc" } }, ["foo"], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
@@ -287,7 +285,7 @@ describe("flatten", () => {
 
 	it("should not mark [[Circular]] reference as editable", () => {
 		const tree = new Map();
-		parseProps("[[Circular]]", [], 2, noop, tree);
+		parseProps("[[Circular]]", [], 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,

--- a/src/view/components/sidebar/inspect/parseProps.test.ts
+++ b/src/view/components/sidebar/inspect/parseProps.test.ts
@@ -3,10 +3,10 @@ import { parseProps } from "./parseProps";
 
 const serialize = (v: Map<any, any>) => Array.from(v.values());
 
-describe("flatten", () => {
+describe("parseProps", () => {
 	it("should flatten strings", () => {
 		const tree = new Map();
-		parseProps("foo", ["foo"], 2, tree);
+		parseProps("foo", "foo", 2, tree);
 
 		expect(serialize(tree)).to.deep.equal([
 			{
@@ -14,7 +14,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "string",
 				value: "foo",
 				children: [],
@@ -24,7 +23,7 @@ describe("flatten", () => {
 
 	it("should flatten numbers", () => {
 		const tree = new Map();
-		parseProps(12, ["foo"], 2, tree);
+		parseProps(12, "foo", 2, tree);
 
 		expect(serialize(tree)).to.deep.equal([
 			{
@@ -32,7 +31,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "number",
 				value: 12,
 				children: [],
@@ -42,7 +40,7 @@ describe("flatten", () => {
 
 	it("should flatten booleans", () => {
 		const tree = new Map();
-		parseProps(false, ["foo"], 2, tree);
+		parseProps(false, "foo", 2, tree);
 
 		expect(serialize(tree)).to.deep.equal([
 			{
@@ -50,7 +48,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "boolean",
 				value: false,
 				children: [],
@@ -60,14 +57,13 @@ describe("flatten", () => {
 
 	it("should flatten null", () => {
 		const tree = new Map();
-		parseProps(null, ["foo"], 2, tree);
+		parseProps(null, "foo", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "null",
 				value: null,
 				children: [],
@@ -77,14 +73,13 @@ describe("flatten", () => {
 
 	it("should flatten undefined", () => {
 		const tree = new Map();
-		parseProps(undefined, ["foo"], 2, tree);
+		parseProps(undefined, "foo", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "undefined",
 				value: undefined,
 				children: [],
@@ -98,14 +93,13 @@ describe("flatten", () => {
 			type: "function",
 			name: "fooBar",
 		};
-		parseProps(fn, ["foo"], 2, tree);
+		parseProps(fn, "foo", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "function",
 				value: fn,
 				children: [],
@@ -115,14 +109,13 @@ describe("flatten", () => {
 
 	it("should flatten arrays", () => {
 		const tree = new Map();
-		parseProps([1, 2], ["foo"], 2, tree);
+		parseProps([1, 2], "foo", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "array",
 				value: [1, 2],
 				children: ["foo.0", "foo.1"],
@@ -132,7 +125,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 1,
 				id: "foo.0",
-				path: ["foo", 0],
 				type: "number",
 				value: 1,
 				children: [],
@@ -142,7 +134,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 1,
 				id: "foo.1",
-				path: ["foo", 1],
 				type: "number",
 				value: 2,
 				children: [],
@@ -152,14 +143,13 @@ describe("flatten", () => {
 
 	it("should not mark empty arrays as collabsible", () => {
 		const tree = new Map();
-		parseProps([], ["foo"], 2, tree);
+		parseProps([], "foo", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "array",
 				value: [],
 				children: [],
@@ -169,14 +159,13 @@ describe("flatten", () => {
 
 	it("should flatten objects", () => {
 		const tree = new Map();
-		parseProps({ foo: 123, bar: "abc" }, [""], 2, tree);
+		parseProps({ foo: 123, bar: "abc" }, "", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
 				editable: false,
 				depth: 0,
 				id: "",
-				path: [""],
 				type: "object",
 				value: {
 					foo: 123,
@@ -189,7 +178,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 1,
 				id: ".foo",
-				path: ["", "foo"],
 				type: "number",
 				value: 123,
 				children: [],
@@ -199,7 +187,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 1,
 				id: ".bar",
-				path: ["", "bar"],
 				type: "string",
 				value: "abc",
 				children: [],
@@ -209,14 +196,13 @@ describe("flatten", () => {
 
 	it("should flatten nested objects", () => {
 		const tree = new Map();
-		parseProps({ foo: { bar: "abc" } }, ["foo"], 4, tree);
+		parseProps({ foo: { bar: "abc" } }, "foo", 4, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "object",
 				value: {
 					foo: {
@@ -230,7 +216,6 @@ describe("flatten", () => {
 				editable: false,
 				depth: 1,
 				id: "foo.foo",
-				path: ["foo", "foo"],
 				type: "object",
 				value: {
 					bar: "abc",
@@ -242,7 +227,6 @@ describe("flatten", () => {
 				editable: true,
 				depth: 2,
 				id: "foo.foo.bar",
-				path: ["foo", "foo", "bar"],
 				type: "string",
 				value: "abc",
 				children: [],
@@ -252,14 +236,13 @@ describe("flatten", () => {
 
 	it("should limit depth", () => {
 		const tree = new Map();
-		parseProps({ foo: { bar: "abc" } }, ["foo"], 2, tree);
+		parseProps({ foo: { bar: "abc" } }, "foo", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: true,
 				editable: false,
 				depth: 0,
 				id: "foo",
-				path: ["foo"],
 				type: "object",
 				value: {
 					foo: {
@@ -273,7 +256,6 @@ describe("flatten", () => {
 				editable: false,
 				depth: 1,
 				id: "foo.foo",
-				path: ["foo", "foo"],
 				type: "object",
 				value: {
 					bar: "abc",
@@ -285,14 +267,13 @@ describe("flatten", () => {
 
 	it("should not mark [[Circular]] reference as editable", () => {
 		const tree = new Map();
-		parseProps("[[Circular]]", [], 2, tree);
+		parseProps("[[Circular]]", "", 2, tree);
 		expect(serialize(tree)).to.deep.equal([
 			{
 				collapsable: false,
 				editable: false,
 				depth: 0,
 				id: "",
-				path: [],
 				type: "string",
 				value: "[[Circular]]",
 				children: [],

--- a/src/view/components/sidebar/inspect/parseProps.ts
+++ b/src/view/components/sidebar/inspect/parseProps.ts
@@ -1,5 +1,3 @@
-import { ObjPath } from "./ElementProps";
-
 export type PropDataType =
 	| "boolean"
 	| "string"
@@ -20,7 +18,6 @@ export interface PropData {
 	id: string;
 	type: PropDataType;
 	value: any;
-	path: ObjPath;
 	editable: boolean;
 	collapsable: boolean;
 	depth: number;
@@ -29,55 +26,51 @@ export interface PropData {
 
 export function parseProps(
 	data: any,
-	path: ObjPath,
+	path: string,
 	limit: number,
 	out: Map<string, PropData>,
 ): Map<string, PropData> {
-	const depth = path.length > 0 ? path.length - 1 : 0;
-	const pathStr = path.join(".");
+	const depth = (path.match(/\./g) || []).length;
 
-	if (path.length > limit) {
+	if (depth >= limit) {
 		return out;
 	}
 
 	if (Array.isArray(data)) {
 		const children: string[] = [];
-		out.set(path.join("."), {
+		out.set(path, {
 			depth,
-			id: pathStr,
+			id: path,
 			type: "array",
 			collapsable: data.length > 0,
 			editable: false,
-			path,
 			value: data,
 			children,
 		});
 		data.forEach((item, i) => {
-			const childPath = path.concat(i);
-			children.push(childPath.join("."));
+			const childPath = `${path}.${i}`;
+			children.push(childPath);
 			parseProps(item, childPath, limit, out);
 		});
 	} else if (data instanceof Set) {
 		// TODO: We're dealing with serialized data here, not a Set object
-		out.set(pathStr, {
+		out.set(path, {
 			depth,
-			id: pathStr,
+			id: path,
 			type: "set",
 			collapsable: false,
 			editable: false,
-			path,
 			value: "Set",
 			children: [],
 		});
 	} else if (typeof data === "object") {
 		if (data === null) {
-			out.set(pathStr, {
+			out.set(path, {
 				depth,
-				id: pathStr,
+				id: path,
 				type: "null",
 				collapsable: false,
 				editable: false,
-				path,
 				value: data,
 				children: [],
 			});
@@ -89,13 +82,12 @@ export function parseProps(
 				typeof data.name === "string" &&
 				data.type === "function"
 			) {
-				out.set(pathStr, {
+				out.set(path, {
 					depth,
-					id: pathStr,
+					id: path,
 					type: "function",
 					collapsable: false,
 					editable: false,
-					path,
 					value: data,
 					children: [],
 				});
@@ -105,13 +97,12 @@ export function parseProps(
 				typeof data.name === "string" &&
 				data.type === "vnode"
 			) {
-				out.set(pathStr, {
+				out.set(path, {
 					depth,
-					id: pathStr,
+					id: path,
 					type: "vnode",
 					collapsable: false,
 					editable: false,
-					path,
 					value: data,
 					children: [],
 				});
@@ -121,13 +112,12 @@ export function parseProps(
 				typeof data.name === "string" &&
 				data.type === "set"
 			) {
-				out.set(pathStr, {
+				out.set(path, {
 					depth,
-					id: pathStr,
+					id: path,
 					type: "set",
 					collapsable: false,
 					editable: false,
-					path,
 					value: data,
 					children: [],
 				});
@@ -137,13 +127,12 @@ export function parseProps(
 				typeof data.name === "string" &&
 				data.type === "map"
 			) {
-				out.set(pathStr, {
+				out.set(path, {
 					depth,
-					id: pathStr,
+					id: path,
 					type: "map",
 					collapsable: false,
 					editable: false,
-					path,
 					value: data,
 					children: [],
 				});
@@ -153,47 +142,44 @@ export function parseProps(
 				typeof data.name === "string" &&
 				data.type === "blob"
 			) {
-				out.set(pathStr, {
+				out.set(path, {
 					depth,
-					id: pathStr,
+					id: path,
 					type: "blob",
 					collapsable: false,
 					editable: false,
-					path,
 					value: data,
 					children: [],
 				});
 			} else {
 				const node: PropData = {
 					depth,
-					id: pathStr,
+					id: path,
 					type: "object",
 					collapsable: Object.keys(data).length > 0,
 					editable: false,
-					path,
 					value: data,
 					children: [],
 				};
-				out.set(pathStr, node);
+				out.set(path, node);
 
 				Object.keys(data).forEach(key => {
-					const nextPath = path.concat(key);
-					node.children.push(nextPath.join("."));
+					const nextPath = `${path}.${key}`;
+					node.children.push(nextPath);
 					parseProps(data[key], nextPath, limit, out);
 				});
 
-				out.set(pathStr, node);
+				out.set(path, node);
 			}
 		}
 	} else {
 		const type = typeof data;
-		out.set(pathStr, {
+		out.set(path, {
 			depth,
-			id: pathStr,
+			id: path,
 			type: type as any,
 			collapsable: false,
 			editable: type !== "undefined" && data !== "[[Circular]]",
-			path,
 			value: data,
 			children: [],
 		});

--- a/src/view/store/props.ts
+++ b/src/view/store/props.ts
@@ -19,7 +19,6 @@ function parseInspectData(
 			depth: 0,
 			editable: false,
 			id: "root",
-			path: ["root"],
 			type: "object",
 			value: null,
 		});
@@ -29,7 +28,7 @@ function parseInspectData(
 			uncollapsed.$ = [];
 		}
 
-		parseProps(getData(v), ["root"], PROPS_LIMIT, tree.$);
+		parseProps(getData(v), "root", PROPS_LIMIT, tree.$);
 	} else {
 		tree.$.clear();
 	}

--- a/src/view/store/props.ts
+++ b/src/view/store/props.ts
@@ -29,7 +29,7 @@ function parseInspectData(
 			uncollapsed.$ = [];
 		}
 
-		parseProps(getData(v), ["root"], PROPS_LIMIT, data => data, tree.$);
+		parseProps(getData(v), ["root"], PROPS_LIMIT, tree.$);
 	} else {
 		tree.$.clear();
 	}


### PR DESCRIPTION
This is in preparation for #143 . Some more refactorings are needed because hooks can have multiple elements with the same name at the same hierarchy level. The current parser doesn't support that. This PR is a step into that direction.