### PR TITLE
Fix only first DOM element highlighted on Fragments

### DIFF
--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -14,7 +14,6 @@ import {
 	getDisplayName,
 	getComponent,
 	getDom,
-	getLastDomChild,
 	getActualChildren,
 	getVNodeParent,
 	hasDom,
@@ -395,7 +394,26 @@ export function createRenderer(
 		inspect: id => inspectVNode(ids, config, id),
 		findDomForVNode(id) {
 			const vnode = getVNodeById(ids, id);
-			return vnode ? [getDom(vnode), getLastDomChild(vnode)] : null;
+			if (!vnode) return null;
+
+			const first = getDom(vnode);
+			let last = null;
+			if (typeof vnode.type === "function") {
+				const children = getActualChildren(vnode);
+				for (let i = children.length - 1; i >= 0; i--) {
+					const child = children[i];
+					if (child) {
+						const dom = getDom(child);
+						if (dom === first) break;
+						if (dom !== null) {
+							last = dom;
+							break;
+						}
+					}
+				}
+			}
+
+			return [first, last];
 		},
 		findVNodeIdForDom(node) {
 			const vnode = domToVNode.get(node);

--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -43,13 +43,6 @@ export function hasDom(x: any) {
 }
 
 /**
- * Get the last dom child of a `vnode`
- */
-export function getLastDomChild(vnode: VNode) {
-	return (vnode as any)._lastDomChild || (vnode as any).__d || null;
-}
-
-/**
  * Check if a `vnode` represents a `Suspense` component
  */
 export function isSuspenseVNode(vnode: VNode) {

--- a/src/adapter/adapter/highlight.ts
+++ b/src/adapter/adapter/highlight.ts
@@ -1,6 +1,6 @@
 import { Renderer } from "../renderer";
 import { render, h } from "preact";
-import { getNearestElement, measureNode } from "../dom";
+import { getNearestElement, measureNode, mergeMeasure } from "../dom";
 import { ID } from "../../view/store/types";
 import { Highlighter, style } from "../../view/components/Highlighter";
 
@@ -40,16 +40,25 @@ export function createHightlighter(renderer: Renderer) {
 				document.body.appendChild(highlightRef);
 			}
 
-			const node = getNearestElement(dom[0]!);
+			const [first, last] = dom;
+
+			const node = getNearestElement(first!);
+			const nodeEnd = last ? getNearestElement(last) : null;
 			if (node != null) {
 				const label = renderer.getDisplayNameById
 					? renderer.getDisplayNameById(id)
 					: renderer.getDisplayName(vnode);
 
+				let size = measureNode(node);
+				if (nodeEnd !== null) {
+					const sizeLast = measureNode(nodeEnd);
+					size = mergeMeasure(size, sizeLast);
+				}
+
 				render(
 					h(Highlighter, {
 						label,
-						...measureNode(node),
+						...size,
 					}),
 					highlightRef,
 				);

--- a/test-e2e/tests/fixtures/highlight-fragment.js
+++ b/test-e2e/tests/fixtures/highlight-fragment.js
@@ -1,0 +1,34 @@
+const { render } = preact;
+
+const css = "background: peachpuff; padding: 2rem; margin-bottom: 1rem;";
+
+function ComponentArray() {
+	return [
+		html`<div style=${css}>A</div>`,
+		html`<div style=${css}>B</div>`,
+		html`<div style=${css}>C</div>`,
+	];
+}
+
+function ComponentFrag() {
+	return html`
+		<div style=${css}>D</div>
+		<div style=${css}>E</div>
+		<div style=${css}>F</div>
+	`;
+}
+
+render(
+	html`
+		<div style="padding: 1rem">
+			<div data-testid="test1">
+				<${ComponentArray} />
+			</div>
+			<hr style="margin: 4rem 0" />
+			<div data-testid="test2">
+				<${ComponentFrag} />
+			</div>
+		</div>
+	`,
+	document.getElementById("app"),
+);

--- a/test-e2e/tests/inspect-fragment.test.ts
+++ b/test-e2e/tests/inspect-fragment.test.ts
@@ -1,0 +1,34 @@
+import { newTestPage, getSize } from "../test-utils";
+import { expect } from "chai";
+import { closePage, waitForTestId } from "pintf/browser_utils";
+
+export const description = "Highlighting combined DOM tree of a Fragment";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "highlight-fragment");
+
+	// 1st test
+	let size = await getSize(page, '[data-testid="test1"]');
+	await devtools.waitForSelector('[data-testid="tree-item"]', {
+		timeout: 2000,
+	});
+
+	const items = await devtools.$$('[data-testid="tree-item"]');
+	await items[0]!.click();
+	await waitForTestId(page, "highlight", { timeout: 2000 });
+
+	let highlight = await getSize(page, '[data-testid="highlight"]');
+	expect(size.width).to.equal(highlight.width);
+	expect(size.height).to.equal(highlight.height);
+
+	// 2nd test
+	size = await getSize(page, '[data-testid="test2"]');
+	await items[1]!.click();
+	await waitForTestId(page, "highlight", { timeout: 2000 });
+
+	highlight = await getSize(page, '[data-testid="highlight"]');
+	expect(size.width).to.equal(highlight.width);
+	expect(size.height).to.equal(highlight.height);
+
+	await closePage(page);
+}


### PR DESCRIPTION
In scenarios where the root `vnode` is a component we'd only highlight the first DOM node.

```jsx
// Only A was highlighted when hovering "MyComponent"
function MyComponent() {
  return (
    <>
      <div>A</div>
      <div>B</div>
    </>
  )
}
```

The same bug happened for components which directly returned an array. Internally Preact will automatically wrap it with a `Fragment` which leads to the same issue as with the component above.

```jsx
// Only A was highlighted when hovering "MyComponent"
function MyComponent() {
  return [
    <div>A</div>,
    <div>B</div>,
  ]
}
```

The main issue in our code was that we checked for a `_lastDomChild`, which was removed a while ago from Preact. Instead we iterate over the inspected `vnode` children backwards until we find a `vnode` with an attached DOM node.

Fixes one of the issues mentioned in #144 .