### PR TITLE
Fix highlight stuck on scroll

### DIFF
--- a/src/adapter/adapter/adapter.ts
+++ b/src/adapter/adapter/adapter.ts
@@ -54,8 +54,10 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 		renderer,
 		id => {
 			highlight.highlight(id);
-			inspect(id);
-			send("select-node", id);
+			if (id > -1) {
+				inspect(id);
+				send("select-node", id);
+			}
 		},
 		() => {
 			send("stop-picker", null);

--- a/src/adapter/adapter/picker.ts
+++ b/src/adapter/adapter/picker.ts
@@ -1,4 +1,5 @@
 import { Renderer } from "../renderer";
+import { debounce } from "../../shells/shared/utils";
 
 export function createPicker(
 	window: Window,
@@ -8,6 +9,7 @@ export function createPicker(
 ) {
 	let picking = false;
 	let lastId = -1;
+	let lastTarget: any = null;
 
 	function clicker(e: MouseEvent) {
 		e.preventDefault();
@@ -19,11 +21,12 @@ export function createPicker(
 	function listener(e: WindowEventMap["mouseover"]) {
 		e.preventDefault();
 		e.stopPropagation();
-		if (picking && e.target != null) {
+		if (picking && e.target != null && lastTarget !== e.target) {
 			const id = renderer.findVNodeIdForDom(e.target as any);
 			if (id > -1 && lastId !== id) {
 				onHover(id);
 			}
+			lastTarget = e.target;
 			lastId = id;
 		}
 	}
@@ -33,14 +36,21 @@ export function createPicker(
 		e.stopPropagation();
 	}
 
+	const onScroll = debounce(() => {
+		onHover(-1);
+		lastId = -1;
+		lastTarget = null;
+	}, 16);
+
 	function start() {
 		if (!picking) {
 			lastId = -1;
 			picking = true;
 			window.addEventListener("mousedown", onMouseEvent, true);
-			window.addEventListener("mouseover", listener, true);
+			window.addEventListener("mousemove", listener, true);
 			window.addEventListener("mouseup", onMouseEvent, true);
 			window.addEventListener("click", clicker, true);
+			document.addEventListener("scroll", onScroll, true);
 		}
 	}
 
@@ -51,9 +61,10 @@ export function createPicker(
 			onStop();
 
 			window.removeEventListener("mousedown", onMouseEvent, true);
-			window.removeEventListener("mouseover", listener, true);
+			window.removeEventListener("mousemove", listener, true);
 			window.removeEventListener("mouseup", onMouseEvent, true);
 			window.removeEventListener("click", clicker, true);
+			document.removeEventListener("scroll", onScroll);
 		}
 	}
 

--- a/test-e2e/test-utils.ts
+++ b/test-e2e/test-utils.ts
@@ -105,6 +105,13 @@ export async function getText(page: Page, selector: string) {
 	return getAttribute(page, selector, "textContent");
 }
 
+export async function hasSelector(page: Page, selector: string) {
+	return page.evaluate(
+		(s: string) => document.querySelector(s) !== null,
+		selector,
+	);
+}
+
 export async function waitForAttribute(
 	page: Page,
 	selector: string,

--- a/test-e2e/tests/fixtures/highlight-scroll.js
+++ b/test-e2e/tests/fixtures/highlight-scroll.js
@@ -1,0 +1,14 @@
+const { render } = preact;
+
+const css =
+	"background: peachpuff; padding: 4rem; margin-bottom: 6rem; margin-right: 4rem";
+
+function Item({ children }) {
+	return html`<div style=${css} data-testid="${children}">${children}</div>`;
+}
+
+function App() {
+	return new Array(100).fill(0).map((_, i) => html`<${Item}>${i}<//>`);
+}
+
+render(html`<${App} />`, document.getElementById("app"));

--- a/test-e2e/tests/inspect-scroll.test.ts
+++ b/test-e2e/tests/inspect-scroll.test.ts
@@ -1,0 +1,33 @@
+import { newTestPage, getSize, click, hasSelector } from "../test-utils";
+import { expect } from "chai";
+import { closePage, waitForTestId } from "pintf/browser_utils";
+import { wait } from "pintf/utils";
+
+export const description = "Highlighting should move with scroll";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "highlight-scroll");
+
+	const inspect = '[data-testid="inspect-btn"]';
+	await click(devtools, inspect);
+
+	await page.hover('[data-testid="0"]');
+
+	await waitForTestId(page, "highlight", { timeout: 2000 });
+
+	const highlight = '[data-testid="highlight"]';
+	const before = await getSize(page, highlight);
+	await page.evaluate(() => {
+		document.querySelector(".test-case")!.scrollBy(0, 1000);
+	});
+	await wait(1000);
+	expect(await hasSelector(page, highlight)).to.equal(false);
+
+	await page.mouse.move(10, 10);
+	expect(await hasSelector(page, highlight)).to.equal(true);
+
+	const after = await getSize(page, highlight);
+	expect(before.top).not.to.equal(after.top);
+
+	await closePage(page);
+}


### PR DESCRIPTION
Whenever the user was in "inspection" mode and scrolled, the highlight overlay would be stuck to the same position relative to the viewport. It didn't match the originally inspected node anymore. I've tried updating the position on scroll, but that is very taxing performance wise. Even with debouncing it feels a bit laggy and unnatural.

So I checked how chrome does it and they remove the highlighter on scroll, but will enable it immediately on the next `mousemove` event. That's what this PR is doing too and it feels much smoother :+1: 

Fixes the second issue mentioned in #144 :tada: 