### PR TITLE
fix(ElementProps.css): fix toggle alignment

### DIFF
--- a/src/view/components/sidebar/inspect/ElementProps.css
+++ b/src/view/components/sidebar/inspect/ElementProps.css
@@ -71,7 +71,6 @@
 .toggle {
 	background: none;
 	display: flex;
-	justify-content: center;
 	align-items: center;
 	height: 100%;
 	width: 100%;


### PR DESCRIPTION
Hi, I found a small style issue. 

**Before:** 
![before](https://user-images.githubusercontent.com/3093946/79479469-15fc2e00-800d-11ea-89b1-c6fe1c66523b.png)
**Now:**
![now](https://user-images.githubusercontent.com/3093946/79479528-2dd3b200-800d-11ea-976a-29f4a898d081.png)
