### PR TITLE
Fix elements only clickable on text

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 			"@typescript-eslint/no-non-null-assertion": "off",
 			"@typescript-eslint/no-unused-vars": "error",
 			"@typescript-eslint/camelcase": "off",
+			"@typescript-eslint/ban-ts-ignore": "off",
 			"react/no-unknown-property": [
 				2,
 				{

--- a/src/view/components/Devtools.css
+++ b/src/view/components/Devtools.css
@@ -14,6 +14,10 @@
 	font-family: sans-serif;
 }
 
+.root * {
+	box-sizing: border-box;
+}
+
 /* Global reset */
 button,
 input {

--- a/src/view/components/elements/TreeView.css
+++ b/src/view/components/elements/TreeView.css
@@ -16,14 +16,6 @@
 	overflow-x: hidden;
 }
 
-.pane {
-	/**
-	 * Hack to get the parent to grow with its children, see:
-	 * https://stackoverflow.com/questions/17291514/how-to-force-parent-div-to-expand-by-child-div-width-padding-margin-box
-	 */
-	display: inline-block;
-}
-
 .empty {
 	display: flex;
 	flex: 1;

--- a/src/view/components/elements/TreeView.tsx
+++ b/src/view/components/elements/TreeView.tsx
@@ -60,6 +60,11 @@ export function TreeView() {
 
 	useEffect(() => {
 		if (ref.current && paneRef.current) {
+			const oldDisplay = paneRef.current.style.display;
+			// Hack to get the parent to grow with its children, see:
+			// https://stackoverflow.com/questions/17291514/how-to-force-parent-div-to-expand-by-child-div-width-padding-margin-box
+			paneRef.current.style.display = "inline-block";
+
 			const available = ref.current.offsetWidth - SCROLLBAR_WIDTH;
 			const actual = paneRef.current.offsetWidth;
 			const diff = actual - available;
@@ -78,6 +83,7 @@ export function TreeView() {
 
 				ref.current.style.setProperty("--indent-depth", `${clamped}px`);
 			}
+			paneRef.current.style.display = oldDisplay;
 		}
 	}, [nodeList, updateCount]);
 

--- a/test-e2e/tests/element-scroll.test.ts
+++ b/test-e2e/tests/element-scroll.test.ts
@@ -1,0 +1,31 @@
+import { newTestPage, installMouseHelper, getText } from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pintf/browser_utils";
+
+export const description = "Clicking at the right of element names #144";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "deep-tree");
+	await installMouseHelper(devtools);
+
+	await page.setViewport({
+		width: 1280,
+		height: 900,
+	});
+
+	const selector = '[data-name="App"]';
+	await devtools.waitForSelector(selector);
+	const { x, y } = await devtools.evaluate((s: string) => {
+		const rect = document.querySelector(s)!.getBoundingClientRect();
+		return { x: rect.right, y: rect.top };
+	}, selector);
+	const offset = await page.evaluate(() => {
+		return document.querySelector("#devtools")!.getBoundingClientRect().top;
+	});
+	await devtools.mouse.click(x - 20, y + offset + 200);
+
+	const text = await getText(devtools, '[data-selected="true"]');
+	expect(text).to.equal("ChildItemName");
+
+	await closePage(page);
+}

--- a/test-e2e/tests/fixtures/deep-tree.js
+++ b/test-e2e/tests/fixtures/deep-tree.js
@@ -1,0 +1,66 @@
+const { render } = preact;
+
+const css = "border: 1px solid peachpuff; padding: 1rem;";
+
+function ChildItemName({ children }) {
+	return html`<div style=${css}>${children}</div>`;
+}
+
+function App() {
+	return html`
+		<${ChildItemName}>
+			<${ChildItemName}>
+				<${ChildItemName}>
+					<${ChildItemName}>
+						<${ChildItemName}>
+							<${ChildItemName}>
+								<${ChildItemName}>
+									<${ChildItemName}>
+										<${ChildItemName}>
+											<${ChildItemName}>
+												<${ChildItemName}>
+													<${ChildItemName}>
+														<${ChildItemName}>
+															<${ChildItemName}>
+																<${ChildItemName}>
+																	<${ChildItemName}>
+																		<${ChildItemName}>Deep<//>
+																	<//>
+																<//>
+															<//>
+														<//>
+													<//>
+												<//>
+											<//>
+										<//>
+									<//>
+								<//>
+							<//>
+						<//>
+					<//>
+				<//>
+			<//>
+		<//>
+		<${ChildItemName}>
+			<${ChildItemName}>
+				<${ChildItemName}>
+					<${ChildItemName}>
+						<${ChildItemName}>
+							<${ChildItemName}>
+								<${ChildItemName}>
+									<${ChildItemName}>
+										<${ChildItemName}>Deep<//>
+									<//>
+								<//>
+							<//>
+						<//>
+					<//>
+				<//>
+			<//>
+		<//>
+	`;
+}
+
+render(html`<${App} />`, document.getElementById("app"));
+
+document.addEventListener("click", e => console.log(e), true);


### PR DESCRIPTION
This was caused by the a wrapper around all elements which is used to determine the total width. The width is the main factor to consider when adapting the indentation to the available space.

Solution is to only do the measuring during resize and let all nodes stretch to the full width afterwards :+1: 

This PR fixes the last issue mentioned in #144 :tada: 