### PR TITLE
Limit key length display

### DIFF
--- a/src/view/components/elements/TreeView.test.tsx
+++ b/src/view/components/elements/TreeView.test.tsx
@@ -1,0 +1,41 @@
+import { h } from "preact";
+import { render } from "@testing-library/preact";
+import { TreeItem } from "./TreeView";
+import { expect } from "chai";
+import { AppCtx } from "../../store/react-bindings";
+import { createStore } from "../../store";
+import { DevNodeType } from "../../store/types";
+
+describe("TreeItem", () => {
+	it("should limit key length to 15", () => {
+		const store = createStore();
+		store.nodes.$.set(1, {
+			children: [],
+			depth: 1,
+			endTime: 0,
+			key: "abcdefghijklmnopqrstuvxyz",
+			id: 1,
+			name: "foo",
+			parent: -1,
+			startTime: 0,
+			treeEndTime: 0,
+			treeStartTime: 0,
+			type: DevNodeType.ClassComponent,
+		});
+		const { container, rerender } = render(
+			<AppCtx.Provider value={store}>
+				<TreeItem id={1} key="" />,
+			</AppCtx.Provider>,
+		);
+		expect(container.textContent).to.equal('foo key="abcdefghijklmno…",');
+
+		store.nodes.$.get(1)!.key = "foobar";
+		rerender(
+			<AppCtx.Provider value={store}>
+				<TreeItem id={1} key="" />,
+			</AppCtx.Provider>,
+		);
+
+		expect(container.textContent).to.equal('foo key="foobar",');
+	});
+});

--- a/src/view/components/elements/TreeView.tsx
+++ b/src/view/components/elements/TreeView.tsx
@@ -197,7 +197,11 @@ export function TreeItem(props: { key: any; id: ID }) {
 					{node.key ? (
 						<span class={s.keyLabel}>
 							{" "}
-							key=&quot;<span class={s.key}>{node.key}</span>&quot;
+							key=&quot;
+							<span class={s.key}>
+								{node.key.length > 15 ? `${node.key.slice(0, 15)}…` : node.key}
+							</span>
+							&quot;
 						</span>
 					) : (
 						""


### PR DESCRIPTION
Keys are often longer than component names and a long key would cause to shrink the indentation very quickly.