### PR TITLE
Sync (only user) selection Profiler -> Elements

### DIFF
--- a/src/view/components/profiler/flamegraph/FlameGraph.tsx
+++ b/src/view/components/profiler/flamegraph/FlameGraph.tsx
@@ -66,6 +66,7 @@ export function FlameGraph() {
 	const onSelect = useCallback(
 		(id: number) => {
 			store.profiler.selectedNodeId.$ = id;
+			store.selection.selectById(id);
 		},
 		[store],
 	);

--- a/test-e2e/tests/sync-selection.test.ts
+++ b/test-e2e/tests/sync-selection.test.ts
@@ -1,0 +1,28 @@
+import { newTestPage, click, getText, clickNestedText } from "../test-utils";
+import { expect } from "chai";
+import { closePage } from "pentf/browser_utils";
+
+export const description = "Sync selection from profiler";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "counter");
+
+	await clickNestedText(devtools, "Counter");
+
+	await click(devtools, '[name="root-panel"][value="PROFILER"]');
+	await click(devtools, '[data-testid="record-btn"]');
+
+	await click(page, "button");
+	await click(devtools, '[data-testid="record-btn"]');
+
+	await devtools.waitForSelector('[data-type="flamegraph"]');
+
+	await clickNestedText(devtools, /^Displ/);
+
+	await click(devtools, '[name="root-panel"][value="ELEMENTS"]');
+
+	const text = await getText(devtools, "[data-selected]");
+	expect(text).to.equal("Display");
+
+	await closePage(page);
+}


### PR DESCRIPTION
Sync selection from Profiler to Elements, but only when the user has clicked a node. This is done on a best effort basis as the Profiler may show nodes, which are not present in the current tree anymore.

Fixes #168 .