### PR TITLE
Fix window resize event never triggered

### DIFF
--- a/src/examples/inline-devtools/setup.tsx
+++ b/src/examples/inline-devtools/setup.tsx
@@ -41,5 +41,5 @@ export function setupFrontendStore(ctx: Window) {
 
 export function setupInlineDevtools(container: HTMLElement, ctx: Window) {
 	const { store } = setupFrontendStore(ctx);
-	render(<DevTools store={store} />, container);
+	render(<DevTools store={store} window={ctx} />, container);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,7 +62,7 @@ container.appendChild(styleGuide);
 
 // Devtools, must be the first one to be initialised
 const { store } = setupFrontendStore(window);
-render(<DevTools store={store} />, devtools);
+render(<DevTools store={store} window={window} />, devtools);
 
 // Preact 10 examples
 initPreact10(hook);

--- a/src/shells/inline/index.ts
+++ b/src/shells/inline/index.ts
@@ -42,10 +42,10 @@ export function setupFrontendStore(ctx: Window) {
 
 export function setupInlineDevtools(container: HTMLElement, ctx: Window) {
 	const { store } = setupFrontendStore(ctx);
-	render(h(DevTools, { store }), container);
+	render(h(DevTools, { store, window: ctx }), container);
 	return store;
 }
 
 export function renderDevtools(store: Store, container: HTMLElement) {
-	render(h(DevTools, { store }), container);
+	render(h(DevTools, { store, window }), container);
 }

--- a/src/shells/shared/panel/panel.ts
+++ b/src/shells/shared/panel/panel.ts
@@ -37,7 +37,7 @@ async function initDevtools() {
 
 	// Render our application
 	const root = window.document.getElementById("root")!;
-	render(h(DevTools, { store }), root);
+	render(h(DevTools, { store, window }), root);
 }
 
 // Send messages from devtools to the content script

--- a/src/shells/shared/utils.ts
+++ b/src/shells/shared/utils.ts
@@ -28,6 +28,20 @@ export function debounce<T extends any[]>(
 	};
 }
 
+export function throttle<T extends any[]>(
+	callback: (...args: T) => void,
+	wait: number,
+) {
+	let running = false;
+	return (...args: T) => {
+		if (!running) {
+			callback(...args);
+			running = true;
+			setTimeout(() => (running = false), wait);
+		}
+	};
+}
+
 export function copyToClipboard(text: string) {
 	const dom = document.createElement("textarea");
 	dom.textContent = text;

--- a/src/view/components/Devtools.tsx
+++ b/src/view/components/Devtools.tsx
@@ -1,5 +1,5 @@
 import { h, Fragment } from "preact";
-import { AppCtx, EmitCtx } from "../store/react-bindings";
+import { AppCtx, EmitCtx, WindowCtx } from "../store/react-bindings";
 import { Store } from "../store/types";
 import { Elements } from "./elements/Elements";
 import { Profiler } from "./profiler/components/Profiler";
@@ -15,7 +15,7 @@ export enum Panel {
 	SETTINGS = "SETTINGS",
 }
 
-export function DevTools(props: { store: Store }) {
+export function DevTools(props: { store: Store; window: Window }) {
 	const [panel, setPanel] = useState<Panel>(Panel.ELEMENTS);
 
 	const showElements = panel === Panel.ELEMENTS;
@@ -23,51 +23,53 @@ export function DevTools(props: { store: Store }) {
 	const showSettings = panel === Panel.SETTINGS;
 
 	return (
-		<EmitCtx.Provider value={props.store.emit}>
-			<AppCtx.Provider value={props.store}>
-				<Fragment>
-					<div class={`${s.theme} ${s.root}`}>
-						<ThemeSwitcher />
-						<SmallTabGroup class={s.switcher}>
-							<div class={s.switcherInner}>
-								<SmallTab
-									onClick={setPanel as any}
-									checked={showElements}
-									name="root-panel"
-									value={Panel.ELEMENTS}
+		<WindowCtx.Provider value={props.window}>
+			<EmitCtx.Provider value={props.store.emit}>
+				<AppCtx.Provider value={props.store}>
+					<Fragment>
+						<div class={`${s.theme} ${s.root}`}>
+							<ThemeSwitcher />
+							<SmallTabGroup class={s.switcher}>
+								<div class={s.switcherInner}>
+									<SmallTab
+										onClick={setPanel as any}
+										checked={showElements}
+										name="root-panel"
+										value={Panel.ELEMENTS}
+									>
+										Elements
+									</SmallTab>
+									<SmallTab
+										onClick={setPanel as any}
+										checked={showProfiler}
+										name="root-panel"
+										value={Panel.PROFILER}
+									>
+										Profiler
+									</SmallTab>
+									<SmallTab
+										onClick={setPanel as any}
+										checked={showSettings}
+										name="root-panel"
+										value={Panel.SETTINGS}
+									>
+										Settings
+									</SmallTab>
+								</div>
+								<a
+									class={s.bugLink}
+									href="https://github.com/preactjs/preact-devtools/issues"
 								>
-									Elements
-								</SmallTab>
-								<SmallTab
-									onClick={setPanel as any}
-									checked={showProfiler}
-									name="root-panel"
-									value={Panel.PROFILER}
-								>
-									Profiler
-								</SmallTab>
-								<SmallTab
-									onClick={setPanel as any}
-									checked={showSettings}
-									name="root-panel"
-									value={Panel.SETTINGS}
-								>
-									Settings
-								</SmallTab>
-							</div>
-							<a
-								class={s.bugLink}
-								href="https://github.com/preactjs/preact-devtools/issues"
-							>
-								Report bug
-							</a>
-						</SmallTabGroup>
-						{showElements && <Elements />}
-						{showProfiler && <Profiler />}
-						{showSettings && <Settings />}
-					</div>
-				</Fragment>
-			</AppCtx.Provider>
-		</EmitCtx.Provider>
+									Report bug
+								</a>
+							</SmallTabGroup>
+							{showElements && <Elements />}
+							{showProfiler && <Profiler />}
+							{showSettings && <Settings />}
+						</div>
+					</Fragment>
+				</AppCtx.Provider>
+			</EmitCtx.Provider>
+		</WindowCtx.Provider>
 	);
 }

--- a/src/view/components/profiler/flamegraph/FlameGraph.tsx
+++ b/src/view/components/profiler/flamegraph/FlameGraph.tsx
@@ -11,7 +11,7 @@ import {
 import { formatTime } from "../util";
 import { CommitData } from "../data/commits";
 import { createFlameGraphStore } from "./FlamegraphStore";
-import { useInstance } from "../../utils";
+import { useInstance, useResize } from "../../utils";
 
 const ROW_HEIGHT = 21; // Account 1px for border
 
@@ -51,14 +51,10 @@ export function FlameGraph() {
 		}
 	}, [ref.current, selectedNodeId, selected, displayType]);
 
-	useEffect(() => {
-		const listener = () => {
-			if (ref.current) {
-				setWidth(ref.current.clientWidth);
-			}
-		};
-		window.addEventListener("resize", listener);
-		return () => window.removeEventListener("resize", listener);
+	useResize(() => {
+		if (ref.current) {
+			setWidth(ref.current.clientWidth);
+		}
 	}, []);
 
 	const isRecording = useObserver(() => store.profiler.isRecording.$);

--- a/src/view/components/utils.ts
+++ b/src/view/components/utils.ts
@@ -1,4 +1,6 @@
-import { useRef, useEffect } from "preact/hooks";
+import { useRef, useEffect, useContext, useLayoutEffect } from "preact/hooks";
+import { WindowCtx } from "../store/react-bindings";
+import { throttle } from "../../shells/shared/utils";
 
 const OFFSET = 16;
 
@@ -71,8 +73,12 @@ export function useInstance<T>(fn: () => T) {
 }
 
 export function useResize(fn: () => void, args: any[]) {
-	useEffect(() => {
-		window.addEventListener("resize", fn);
-		return () => window.removeEventListener("resize", fn);
+	const window = useContext(WindowCtx);
+	const fn2 = throttle(fn, 100);
+	useLayoutEffect(() => {
+		window.addEventListener("resize", fn2);
+		return () => {
+			window.removeEventListener("resize", fn2);
+		};
 	}, args);
 }

--- a/src/view/components/utils.ts
+++ b/src/view/components/utils.ts
@@ -73,12 +73,18 @@ export function useInstance<T>(fn: () => T) {
 }
 
 export function useResize(fn: () => void, args: any[]) {
-	const window = useContext(WindowCtx);
+	// If we're running inside the browser extension context
+	// we pull the correct window reference from context. And
+	// yes there are multiple `window` objects to keep track of.
+	// If you subscribe to the wrong one, nothing will be
+	// triggered. For testing scenarios we can fall back to
+	// the global window object instead.
+	const win = useContext(WindowCtx) || window;
 	const fn2 = throttle(fn, 100);
 	useLayoutEffect(() => {
-		window.addEventListener("resize", fn2);
+		win.addEventListener("resize", fn2);
 		return () => {
-			window.removeEventListener("resize", fn2);
+			win.removeEventListener("resize", fn2);
 		};
 	}, args);
 }

--- a/src/view/store/react-bindings.ts
+++ b/src/view/store/react-bindings.ts
@@ -4,6 +4,10 @@ import { Store } from "./types";
 import { EmitFn } from "../../adapter/hook";
 import { watch, Observable } from "../valoo";
 
+// Make sure we're accessing the right window object. The global window
+// reference is not the same and won't trigger any "resize" (and likely
+// other) events at all.
+export const WindowCtx = createContext<Window>(null as any);
 export const AppCtx = createContext<Store>(null as any);
 export const EmitCtx = createContext<EmitFn>(() => null);
 


### PR DESCRIPTION
In browser-extension land one has to keep track of multiple different `window` references. If you attach your event handlers to the wrong one, nothing will be emitted. What's more confusing is that the global `window` object is rarely the one you actually want, and I too fell victim to that.