### PR TITLE
Make flame graph animations less demanding on GPU

### DIFF
--- a/src/view/components/profiler/flamegraph/FlameGraph.css
+++ b/src/view/components/profiler/flamegraph/FlameGraph.css
@@ -31,9 +31,8 @@
 	background: var(--color-profiler-old);
 }
 
-.node[data-overflow] {
-	color: transparent;
-	padding: 0;
+.node[data-overflow] .text {
+	display: none;
 }
 
 .node[data-weight="-1"]:not([data-overflow]) {

--- a/src/view/components/profiler/flamegraph/FlameGraph.css
+++ b/src/view/components/profiler/flamegraph/FlameGraph.css
@@ -16,7 +16,8 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	transition: all 0.3s;
+	transition-property: all;
+	transition-duration: 0.3s;
 	padding-bottom: 1px;
 }
 

--- a/src/view/components/profiler/flamegraph/FlameGraph.tsx
+++ b/src/view/components/profiler/flamegraph/FlameGraph.tsx
@@ -101,8 +101,10 @@ export function FlameGraph() {
 							transform: `translate3d(${x}px,${y}px,0)`,
 						}}
 					>
-						{node.name} ({formatTime(node.selfDuration)} of{" "}
-						{formatTime(node.treeEndTime - node.treeStartTime)})
+						<span class={s.text}>
+							{node.name} ({formatTime(node.selfDuration)} of{" "}
+							{formatTime(node.treeEndTime - node.treeStartTime)})
+						</span>
 					</div>
 				);
 			})}

--- a/src/view/components/profiler/flamegraph/FlameGraph.tsx
+++ b/src/view/components/profiler/flamegraph/FlameGraph.tsx
@@ -94,7 +94,7 @@ export function FlameGraph() {
 						}
 						data-maximized={i <= selectedIndex}
 						data-selected={selectedNodeId === meta.id}
-						data-overflow={width <= 24}
+						data-overflow={width <= 32}
 						style={{
 							width: Math.max(2, width), // 2 for HiDPI screens
 							height: ROW_HEIGHT,

--- a/src/view/components/profiler/flamegraph/FlameGraph.tsx
+++ b/src/view/components/profiler/flamegraph/FlameGraph.tsx
@@ -12,6 +12,7 @@ import { formatTime } from "../util";
 import { CommitData } from "../data/commits";
 import { createFlameGraphStore } from "./FlamegraphStore";
 import { useInstance, useResize } from "../../utils";
+import { ID } from "../../../store/types";
 
 const ROW_HEIGHT = 21; // Account 1px for border
 
@@ -23,6 +24,12 @@ const EMTPY: CommitData = {
 	duration: 0,
 	nodes: new Map(),
 };
+
+export interface TransformData {
+	transform: string;
+	opacity: number;
+	width: number;
+}
 
 export function FlameGraph() {
 	const store = useStore();
@@ -41,6 +48,20 @@ export function FlameGraph() {
 		() => nodes.findIndex(x => x.id === selectedNodeId),
 		[selectedNodeId, nodes],
 	);
+
+	const cache = useRef(new Map<ID, TransformData>());
+	const oldPosition = useMemo(() => {
+		const cacheNew = new Map<ID, TransformData>();
+		nodes.forEach(node => {
+			if (cache.current.has(node.id)) {
+				cacheNew.set(node.id, cache.current.get(node.id)!);
+			} else {
+				cacheNew.set(node.id, { transform: "", opacity: 0, width: 0 });
+			}
+		});
+		cache.current = cacheNew;
+		return cacheNew;
+	}, [commit.commitRootId]);
 
 	const displayType = useObserver(() => store.profiler.flamegraphType.$);
 	const [canvasWidth, setWidth] = useState(100);
@@ -83,6 +104,21 @@ export function FlameGraph() {
 
 				const node = commit.nodes.get(meta.id)!;
 
+				const pos = oldPosition.get(meta.id)!;
+				let property = "opacity";
+				if (
+					activeParents.has(meta.id) ||
+					(x >= 0 && x <= canvasWidth) ||
+					(x + width >= 0 && x + width <= canvasWidth)
+				) {
+					if (pos.opacity > 0) property = "all";
+					pos.transform = `translate3d(${x}px,${y}px,0)`;
+					pos.opacity = 1;
+					pos.width = Math.max(2, width); // 2 for HiDPI screens
+				} else {
+					pos.opacity = 0;
+				}
+
 				const color = colorMap.get(meta.id);
 				return (
 					<div
@@ -96,9 +132,11 @@ export function FlameGraph() {
 						data-selected={selectedNodeId === meta.id}
 						data-overflow={width <= 32}
 						style={{
-							width: Math.max(2, width), // 2 for HiDPI screens
+							width: pos.width,
 							height: ROW_HEIGHT,
-							transform: `translate3d(${x}px,${y}px,0)`,
+							opacity: pos.opacity,
+							transform: pos.transform,
+							transitionProperty: property,
 						}}
 					>
 						<span class={s.text}>


### PR DESCRIPTION
This PR improves responsiveness for large flame graphs a lot by only doing complex animations on nodes that are within the viewport. Nodes that would be hidden are simply faded out, therefore skipping expensive `width` and text ellipsis calculations.

The performance improvement is very noticeable on my Dell XPS 13.