### PR TITLE
Only show selftime in ranked Flamegraph

### DIFF
--- a/src/view/components/profiler/flamegraph/FlameGraph.tsx
+++ b/src/view/components/profiler/flamegraph/FlameGraph.tsx
@@ -9,7 +9,7 @@ import {
 	useMemo,
 } from "preact/hooks";
 import { formatTime } from "../util";
-import { CommitData } from "../data/commits";
+import { CommitData, FlamegraphType } from "../data/commits";
 import { createFlameGraphStore } from "./FlamegraphStore";
 import { useInstance, useResize } from "../../utils";
 import { ID } from "../../../store/types";
@@ -140,8 +140,10 @@ export function FlameGraph() {
 						}}
 					>
 						<span class={s.text}>
-							{node.name} ({formatTime(node.selfDuration)} of{" "}
-							{formatTime(node.treeEndTime - node.treeStartTime)})
+							{node.name} ({formatTime(node.selfDuration)}
+							{displayType === FlamegraphType.FLAMEGRAPH &&
+								"of " + formatTime(node.treeEndTime - node.treeStartTime)}
+							)
 						</span>
 					</div>
 				);

--- a/test-e2e/tests/profiler/profiler-ranked.test.ts
+++ b/test-e2e/tests/profiler/profiler-ranked.test.ts
@@ -1,4 +1,9 @@
-import { newTestPage, click, waitForAttribute } from "../../test-utils";
+import {
+	newTestPage,
+	click,
+	waitForAttribute,
+	getText,
+} from "../../test-utils";
 import { expect } from "chai";
 import { closePage } from "pentf/browser_utils";
 
@@ -25,6 +30,13 @@ export async function run(config: any) {
 		'[data-type="ranked"] > *:not([data-weight])',
 	);
 	expect(nodes.length).to.equal(0);
+
+	// Only shows self time
+	const text = await getText(
+		devtools,
+		'[data-type="ranked"] [data-weight]:first-child',
+	);
+	expect(text).to.match(/Counter \([0-9]+(\.[0-9]+)?ms\)/);
 
 	await closePage(page);
 }


### PR DESCRIPTION
The total duration including children isn't of much value in this view mode.