### PR TITLE
Fix report bug link not working

### DIFF
--- a/src/view/components/Devtools.tsx
+++ b/src/view/components/Devtools.tsx
@@ -59,6 +59,8 @@ export function DevTools(props: { store: Store; window: Window }) {
 								<a
 									class={s.bugLink}
 									href="https://github.com/preactjs/preact-devtools/issues"
+									target="_blank"
+									rel="noopener noreferrer"
 								>
 									Report bug
 								</a>


### PR DESCRIPTION
When running inside Chrome, the "Report Bug" link tries to navigate the devtools panel to GitHub which Chrome rejects. Adding `target="_blank"` to the link makes it open in a new tab.