### PR TITLE
Fix trying to set popup on closed tab

### DIFF
--- a/src/shells/shared/background/background.ts
+++ b/src/shells/shared/background/background.ts
@@ -29,7 +29,6 @@ function addToTarget(tabId: number, port: chrome.runtime.Port) {
 			source: DevtoolsToClient,
 		});
 		target.off(port.name);
-		setPopupStatus(tabId, false);
 	});
 }
 
@@ -57,12 +56,7 @@ function handleDevtoolsConnection(port: chrome.runtime.Port) {
 		addToTarget(tabId, port);
 		port.onMessage.removeListener(initialListener);
 
-		if (
-			targets
-				.get(tabId)
-				?.connected()
-				.includes(ContentScriptName)
-		) {
+		if (targets.get(tabId)?.connected().includes(ContentScriptName)) {
 			port.postMessage({ type: "init", data: null });
 		}
 	}


### PR DESCRIPTION
This is not necessary as panels are seemingly reset on each navigation request. Fixes the following error:

```txt
Unchecked lastError value: Error: Invalid tab ID: 9
```