### PR TITLE
Sync selection

### DIFF
--- a/src/adapter/adapter/adapter.ts
+++ b/src/adapter/adapter/adapter.ts
@@ -77,7 +77,15 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 		}
 	});
 
-	listen("inspect", id => inspect(id));
+	listen("inspect", id => {
+		if (id !== null && renderer.has(id)) {
+			const res = renderer.findDomForVNode(id);
+			if (res && res.length > 0) {
+				(window as any).__PREACT_DEVTOOLS__.$0 = res[0];
+			}
+		}
+		inspect(id);
+	});
 
 	listen("log", e => {
 		if (renderer.has(e.id)) {

--- a/src/adapter/adapter/adapter.ts
+++ b/src/adapter/adapter/adapter.ts
@@ -1,4 +1,4 @@
-import { DevtoolEvents } from "../hook";
+import { DevtoolEvents, DevtoolsHook } from "../hook";
 import { Renderer } from "../renderer";
 import { copyToClipboard } from "../../shells/shared/utils";
 import { createPicker } from "./picker";
@@ -148,6 +148,17 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 	listen("stop-highlight-updates", () => {
 		if (renderer.stopHighlightUpdates) {
 			renderer.stopHighlightUpdates();
+		}
+	});
+
+	listen("load-host-selection", () => {
+		const hook: DevtoolsHook = (window as any).__PREACT_DEVTOOLS__;
+		const selected = hook.$0;
+		if (selected) {
+			const id = renderer.findVNodeIdForDom(selected);
+			if (id > -1) {
+				send("select-node", id);
+			}
 		}
 	});
 }

--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -32,6 +32,7 @@ export interface DevtoolEvents {
 	"reload-and-profile": ProfilerOptions;
 	"update-filter": RawFilterState;
 	"load-host-selection": null;
+	"inspect-host-node": null;
 	copy: string;
 	highlight: ID | null;
 	log: { id: ID; children: ID[] };

--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -31,6 +31,7 @@ export interface DevtoolEvents {
 	"stop-highlight-updates": null;
 	"reload-and-profile": ProfilerOptions;
 	"update-filter": RawFilterState;
+	"load-host-selection": null;
 	copy: string;
 	highlight: ID | null;
 	log: { id: ID; children: ID[] };
@@ -50,6 +51,8 @@ export type EmitFn = <K extends keyof DevtoolEvents>(
 ) => void;
 
 export interface DevtoolsHook {
+	/** Currently selected node in the native browser's Elements panel */
+	$0: HTMLElement | null;
 	connected: boolean;
 	emit: EmitFn;
 	listen: (fn: (name: string, cb: any) => any) => void;
@@ -121,6 +124,7 @@ export function createHook(port: PortPageHook): DevtoolsHook {
 	};
 
 	return {
+		$0: null,
 		renderers,
 		get connected() {
 			return status === "connected";

--- a/src/shells/shared/panel/panel.ts
+++ b/src/shells/shared/panel/panel.ts
@@ -12,10 +12,20 @@ import {
 	storeHighlightUpdates,
 } from "./settings";
 
-async function showPanel(): Promise<Window> {
+// Updated when the selection in the native elements panel changed.
+let hostSelectionChanged = false;
+
+async function showPanel(): Promise<{
+	window: Window;
+	panel: chrome.devtools.panels.ExtensionPanel;
+}> {
 	return new Promise(resolve => {
 		chrome.devtools.panels.create("Preact", "", "/panel/panel.html", panel => {
-			panel.onShown.addListener(window => resolve(window));
+			const fn = (window: Window) => {
+				resolve({ window, panel });
+				panel.onShown.removeListener(fn);
+			};
+			panel.onShown.addListener(fn);
 		});
 	});
 }
@@ -28,9 +38,29 @@ let initialized = false;
 
 const store = createStore();
 
+// Sync selection from browser to devtools
+chrome.devtools.panels.elements.onSelectionChanged.addListener(() => {
+	store.emit("load-host-selection", null);
+	chrome.devtools.inspectedWindow.eval(
+		`window.__PREACT_DEVTOOLS__ && window.__PREACT_DEVTOOLS__.$0 !== $0
+			? (window.__PREACT_DEVTOOLS__.$0 = $0, true)
+			: false
+		`,
+		(result: boolean) => {
+			hostSelectionChanged = result;
+		},
+	);
+});
+
 async function initDevtools() {
 	initialized = true;
-	const window = await showPanel();
+	const { window, panel } = await showPanel();
+	panel.onShown.addListener(() => {
+		if (hostSelectionChanged) {
+			hostSelectionChanged = false;
+			store.emit("load-host-selection", null);
+		}
+	});
 
 	// Settings
 	await loadSettings(window, store);

--- a/src/view/components/elements/TreeView.tsx
+++ b/src/view/components/elements/TreeView.tsx
@@ -58,6 +58,17 @@ export function TreeView() {
 	const [updateCount, setUpdateCount] = useState(0);
 	useResize(() => setUpdateCount(updateCount + 1), [updateCount]);
 
+	useEffect(() => {
+		if (ref.current) {
+			const selectedNode = ref.current.querySelector(
+				'[data-selected="true"]',
+			) as any;
+			if (selectedNode) {
+				scrollIntoView(selectedNode);
+			}
+		}
+	}, []);
+
 	const [maxIndent, setMaxIndent] = useState(0);
 
 	useEffect(() => {

--- a/src/view/components/icons.tsx
+++ b/src/view/components/icons.tsx
@@ -75,6 +75,19 @@ export function BugIcon({ size = "s" }: Props) {
 	);
 }
 
+export function InspectNativeIcon({ size = "s" }: Props) {
+	return createSvgIcon(
+		size,
+		<Fragment>
+			<path d="M0 0h24v24H0z" fill="none" />
+			<path
+				d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+				fill="currentColor"
+			/>
+		</Fragment>,
+	);
+}
+
 export function Remove({ size = "s" }: Props) {
 	return createSvgIcon(
 		size,

--- a/src/view/components/profiler/components/SidebarHeader.tsx
+++ b/src/view/components/profiler/components/SidebarHeader.tsx
@@ -9,7 +9,7 @@ import {
 import { ComponentName } from "../../ComponentName";
 import { useCallback } from "preact/hooks";
 import { IconBtn } from "../../IconBtn";
-import { BugIcon } from "../../icons";
+import { BugIcon, InspectNativeIcon } from "../../icons";
 
 export function SidebarHeader() {
 	const store = useStore();
@@ -18,11 +18,19 @@ export function SidebarHeader() {
 	const log = useCallback(() => {
 		if (selected) emit("log", { id: selected.id, children: selected.children });
 	}, [selected]);
+	const inspectHostNode = useCallback(() => {
+		emit("inspect-host-node", null);
+	}, []);
 
 	return (
 		<Actions class={s.actions}>
 			<ComponentName>{selected && selected.name}</ComponentName>
 			<div class={s.iconActions}>
+				{selected && (
+					<IconBtn title="Show matching DOM element" onClick={inspectHostNode}>
+						<InspectNativeIcon />
+					</IconBtn>
+				)}
 				{selected && (
 					<IconBtn title="Log internal vnode" onClick={log}>
 						<BugIcon />

--- a/src/view/components/sidebar/SidebarActions.tsx
+++ b/src/view/components/sidebar/SidebarActions.tsx
@@ -2,7 +2,7 @@ import { h } from "preact";
 import s from "./Sidebar.css";
 import { Actions } from "../Actions";
 import { IconBtn } from "../IconBtn";
-import { Refresh, BugIcon } from "../icons";
+import { Refresh, BugIcon, InspectNativeIcon } from "../icons";
 import { useStore, useEmitter, useObserver } from "../../store/react-bindings";
 import { useCallback } from "preact/hooks";
 import { ComponentName } from "../ComponentName";
@@ -19,12 +19,20 @@ export function SidebarActions() {
 	const log = useCallback(() => {
 		if (node) emit("log", { id: node.id, children: node.children });
 	}, [node]);
+	const inspectHostNode = useCallback(() => {
+		emit("inspect-host-node", null);
+	}, []);
 
 	return (
 		<Actions class={s.actions}>
 			<ComponentName>{node && node.name}</ComponentName>
 
 			<div class={s.iconActions}>
+				{node && (
+					<IconBtn title="Show matching DOM element" onClick={inspectHostNode}>
+						<InspectNativeIcon />
+					</IconBtn>
+				)}
 				{node && node.name[0] === node.name[0].toUpperCase() && (
 					<IconBtn title="Re-render Component" onClick={forceUpdate}>
 						<Refresh />

--- a/src/view/store/types.ts
+++ b/src/view/store/types.ts
@@ -4,7 +4,7 @@ import { createSearchStore } from "./search";
 import { createFilterStore } from "./filter";
 import { createSelectionStore } from "./selection";
 import { Collapser } from "./collapser";
-import { EmitFn } from "../../adapter/hook";
+import { EmitFn, DevtoolEvents } from "../../adapter/hook";
 import { ProfilerState } from "../components/profiler/data/commits";
 import { PropData } from "../components/sidebar/inspect/parseProps";
 
@@ -93,4 +93,7 @@ export interface Store {
 	subscribe(fn: Listener): () => void;
 }
 
-export type Listener = (name: string, data: any) => void;
+export type Listener = <K extends keyof DevtoolEvents>(
+	name: K,
+	data: DevtoolEvents[K],
+) => void;


### PR DESCRIPTION
This PR syncs the selection from the browser's elements panel to our extension. The other direction isn't really possible, because syncing would always cause the active tab to switch to the native elements panel. Therefore we've introduced a button in the sidebar to do it on user action.