### PR TITLE
Remove common headline in settings

### DIFF
--- a/src/view/components/settings/Settings.css
+++ b/src/view/components/settings/Settings.css
@@ -25,3 +25,7 @@ h2 {
 	margin-bottom: 2rem;
 	font-size: 0.9rem;
 }
+
+.settingSpace {
+	margin-bottom: 2rem;
+}

--- a/src/view/components/settings/Settings.tsx
+++ b/src/view/components/settings/Settings.tsx
@@ -48,7 +48,7 @@ export function Settings() {
 				>
 					Capture render reasons
 				</Checkbox>
-				<div class={s.message}>
+				<div class={`${s.message} ${s.settingSpace}`}>
 					<Message type="info">
 						All props, state, and hooks of the current node will be compared to
 						the previous node to determine what changed between renders. Timings
@@ -56,7 +56,6 @@ export function Settings() {
 					</Message>
 				</div>
 
-				<h2>Common</h2>
 				<label class={s.label}>Theme:</label>
 				<RadioBar
 					name="theme"


### PR DESCRIPTION
Remove the common headline to tidy up the available space

![Screenshot from 2020-05-21 22-14-23](https://user-images.githubusercontent.com/1062408/82601834-76543180-9bb0-11ea-9ecc-08957cbe6736.png)
