### PR TITLE
Fix undefined component with prefresh

### DIFF
--- a/src/adapter/10/options.ts
+++ b/src/adapter/10/options.ts
@@ -78,7 +78,7 @@ export function setupOptions(
 
 		o._hook = o.__h = (c: Component, index: number, type: number) => {
 			const s = getStatefulHooks(c);
-			if (Array.isArray(s) && getComponent(s[0])) {
+			if (s && Array.isArray(s) && s.length > 0 && getComponent(s[0])) {
 				s[0]._oldValue = getStatefulHookValue(s);
 				s[0]._index = index;
 			}


### PR DESCRIPTION
Noticed this when playing around with some prefresh demos, but haven't found a way to reliably reproduce it in a test case.