### PR TITLE
Fix error on highlighting text node

### DIFF
--- a/test-e2e/tests/fixtures/highlight-text.js
+++ b/test-e2e/tests/fixtures/highlight-text.js
@@ -1,0 +1,19 @@
+const { h, render } = preact;
+const { useState } = preactHooks;
+
+function Display(props) {
+	return `Counter: ${props.value}`;
+}
+
+function Counter() {
+	const [v, set] = useState(0);
+
+	return html`
+		<div style="padding: 2rem;">
+			<${Display} value=${v} />
+			<button onClick=${() => set(v + 1)}>Increment</button>
+		</div>
+	`;
+}
+
+render(h(Counter), document.getElementById("app"));

--- a/test-e2e/tests/profiler/highlight-updates-text.test.ts
+++ b/test-e2e/tests/profiler/highlight-updates-text.test.ts
@@ -1,0 +1,29 @@
+import {
+	newTestPage,
+	click,
+	clickTab,
+	checkNotPresent,
+} from "../../test-utils";
+import { closePage } from "pentf/browser_utils";
+import { wait } from "pentf/utils";
+
+export const description = "Don't crash on measuring text nodes";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "highlight-text");
+	await page.waitForSelector("button");
+
+	await clickTab(devtools, "SETTINGS");
+	await click(devtools, '[data-testId="toggle-highlight-updates"]');
+
+	await click(page, "button");
+
+	// Run twice to check if canvas is re-created
+	const id = "#preact-devtools-highlight-updates";
+	await page.waitForSelector(id);
+
+	await wait(1000);
+	await checkNotPresent(page, id);
+
+	await closePage(page);
+}


### PR DESCRIPTION
When "Highlight Updates" is enabled in settings we'd sometimes get an error that `dom.getBoundingClientRect()` is `undefined`. This happens because the `vnode.dom` pointer may point to a `Text` node. Those don't have the `getBoundingClientRect` method.

So the fix is to instead use the nearest `parentNode`.

Fixes #225 .