### PR TITLE
Save component filters in browser settings

### DIFF
--- a/.changeset/ninety-jokes-joke.md
+++ b/.changeset/ninety-jokes-joke.md
@@ -1,0 +1,5 @@
+---
+"preact-devtools": patch
+---
+
+Save component filters in browser settings and restore them upon opening the devtools panel

--- a/src/adapter/adapter/filter.ts
+++ b/src/adapter/adapter/filter.ts
@@ -1,5 +1,7 @@
+import { RawFilter } from "../../view/store/filter";
+
 export interface RawFilterState {
-	regex: string[];
+	regex: RawFilter[];
 	type: {
 		fragment: boolean;
 		dom: boolean;
@@ -19,7 +21,7 @@ export function parseFilters(raw: RawFilterState): FilterState {
 	if (raw.type.dom) type.add("dom");
 
 	return {
-		regex: raw.regex.map(x => new RegExp(x, "gi")),
+		regex: raw.regex.filter(x => x.enabled).map(x => new RegExp(x.value, "gi")),
 		type,
 	};
 }

--- a/src/shells/shared/panel/panel.ts
+++ b/src/shells/shared/panel/panel.ts
@@ -10,6 +10,7 @@ import {
 	storeCaptureRenderReasons,
 	storeDebugMode,
 	storeHighlightUpdates,
+	storeFilters,
 } from "./settings";
 
 // Updated when the selection in the native elements panel changed.
@@ -121,6 +122,8 @@ const destroy = store.subscribe((type, data) => {
 				})()
 			`);
 		}, 100);
+	} else if (type === "update-filter") {
+		storeFilters(data as any);
 	}
 });
 

--- a/src/shells/shared/panel/settings.ts
+++ b/src/shells/shared/panel/settings.ts
@@ -1,3 +1,4 @@
+import { RawFilterState } from "../../../adapter/adapter/filter";
 import { Store } from "../../../view/store/types";
 
 /**
@@ -11,7 +12,13 @@ export async function loadSettings(window: Window, store: Store) {
 	try {
 		const settings: any = await new Promise(res => {
 			chrome.storage.sync.get(
-				["theme", "captureRenderReasons", "debugMode", "highlightUpdates"],
+				[
+					"theme",
+					"captureRenderReasons",
+					"debugMode",
+					"highlightUpdates",
+					"componentFilters",
+				],
 				res,
 			);
 		});
@@ -23,12 +30,19 @@ export async function loadSettings(window: Window, store: Store) {
 			store.profiler.captureRenderReasons.$ = !!settings.captureRenderReasons;
 			store.profiler.highlightUpdates.$ = !!settings.highlightUpdates;
 			store.debugMode.$ = !!settings.debugMode;
+			if (settings.componentFilters) {
+				store.filter.restore(settings.componentFilters);
+			}
 		}
 	} catch (e) {
 		// We don't really care if we couldn't load the settings
 		// eslint-disable-next-line no-console
 		console.error(e);
 	}
+}
+
+export function storeFilters(state: RawFilterState) {
+	store({ componentFilters: state });
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/view/store/filter.ts
+++ b/src/view/store/filter.ts
@@ -23,10 +23,22 @@ export function createFilterStore(
 			},
 		};
 
-		filters.$.filter(x => x.enabled).forEach(x => {
-			s.regex.push(escapeStringRegexp(x.value));
+		filters.$.forEach(x => {
+			s.regex.push({ value: escapeStringRegexp(x.value), enabled: x.enabled });
 		});
 		onSubmit("update-filter", s);
+	};
+
+	const restore = (state: RawFilterState) => {
+		try {
+			filterFragment.$ = !!state.type.fragment;
+			filterDom.$ = !!state.type.dom;
+			filterDom.$ = !!state.type.dom;
+			filters.$ = state.regex;
+		} catch (err) {
+			// eslint-disable-next-line no-console
+			console.log(err);
+		}
 	};
 
 	return {
@@ -66,5 +78,6 @@ export function createFilterStore(
 			}
 		},
 		submit,
+		restore,
 	};
 }


### PR DESCRIPTION
This PR saves the component filter view to the browser settings. They will be restored whenever the devtools panel is re-opened.

Fixes #246 .