### PR TITLE
Fix TypeError dom is null in updateHighlight

### DIFF
--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -125,13 +125,16 @@ export function getFilteredChildren(
 	return out.reverse();
 }
 
+function isTextNode(dom: HTMLElement | Text | null): dom is Text {
+	return dom != null && dom.nodeType === NodeType.Text;
+}
+
 function updateHighlight(profiler: ProfilerState, vnode: VNode) {
 	if (profiler.highlightUpdates && typeof vnode.type === "function") {
 		let dom = getDom(vnode);
-		if (dom.nodeType === NodeType.Text) {
-			dom = dom.parentNode;
+		if (isTextNode(dom)) {
+			dom = dom.parentNode as HTMLElement;
 		}
-
 		if (dom && !profiler.pendingHighlightUpdates.has(dom)) {
 			profiler.pendingHighlightUpdates.add(dom);
 			measureUpdate(profiler.updateRects, dom);

--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-mixed-spaces-and-tabs */
 import { Component, VNode } from "preact";
 import { RendererConfig10 } from "./renderer";
 import { HookType } from "../../constants";
@@ -35,7 +34,7 @@ export function getComponent(vnode: VNode | any): Component | null {
 /**
  * Get a `vnode`'s _dom reference.
  */
-export function getDom(vnode: VNode) {
+export function getDom(vnode: VNode): HTMLElement | Text | null {
 	return (vnode as any)._dom || (vnode as any).__e || null;
 }
 
@@ -63,8 +62,8 @@ export function getStatefulHooks(c: Component) {
 	const hooks = getComponentHooks(c);
 	return hooks !== null
 		? hooks._list ||
-		  hooks.__ ||
-		  hooks.i || // Preact 10.1.0
+				hooks.__ ||
+				hooks.i || // Preact 10.1.0
 				null
 		: null;
 }

--- a/src/adapter/adapter/highlight.ts
+++ b/src/adapter/adapter/highlight.ts
@@ -44,11 +44,7 @@ export function createHightlighter(renderer: Renderer) {
 			let [first, last] = dom;
 			if (first === null) return;
 
-			if (first.nodeType === Node.TEXT_NODE) {
-				first = first.parentNode as any;
-			}
-
-			const node = getNearestElement(first!);
+			const node = getNearestElement(first);
 			const nodeEnd = last ? getNearestElement(last) : null;
 			if (node != null) {
 				const label = renderer.getDisplayNameById


### PR DESCRIPTION
Regression introduced by preactjs/preact-devtools#244 which checks nodeType of a maybe null value.

Basic fix is to check the null, but introduce a little more typing demonstrating how errors like this can be avoided. One new function isTextNode is a narrowing type guard. Doing the same thing inline unfortunately is not nearly as neat.

Drive-by unmix tabs and spaces for everyone's sanity.

Traceback from using latest devtools release:
```
Uncaught (in promise) TypeError: dom is null
    updateHighlight (index):2571
    mount (index):2609
    update (index):2681
    update (index):2668
    update (index):2722
    createCommit (index):2773
    onCommit (index):2962
```

And just a general observation, the code has a lot of telling the type checker to shut up with `any` casts. It looks like importing at least `VNode` from `preact/internal` would make life easier, worth trying as a change? It has the `HTMLElement | Text | null` annotation on `_dom` for instance.