### PR TITLE
Fix horizontal sidebar scroll on low depth

### DIFF
--- a/.changeset/new-knives-doubt.md
+++ b/.changeset/new-knives-doubt.md
@@ -1,0 +1,5 @@
+---
+"preact-devtools": patch
+---
+
+Fix horizontal sidebar scroll on low depth elements

--- a/src/view/components/sidebar/inspect/ElementProps.tsx
+++ b/src/view/components/sidebar/inspect/ElementProps.tsx
@@ -105,9 +105,7 @@ export function SingleItem(props: SingleProps) {
 			class={s.row}
 			data-testid="props-row"
 			data-depth={depth}
-			style={`transform: translate3d(calc(var(--indent-depth) * ${
-				depth - 1
-			}), 0, 0);`}
+			style={`padding-left: calc(var(--indent-depth) * ${depth - 1})`}
 		>
 			{collapseable && (
 				<button


### PR DESCRIPTION
There will still be a scrollbar when elements are nested too deep in the sidebar, so we likely need a better long term solution, similar to what we do in the elements panel. For now this is a good enough workaround though.