### PR TITLE
Refine types on vnode utility functions

### DIFF
--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -699,8 +699,9 @@ export function createRenderer(
 				const c = getComponent(vnode);
 				if (c) {
 					const s = getHookState(c, index);
-					// TODO: How do we know it's okay to assign like this? Hook state varies.
-					(s as any)[0] = value;
+					// Only useState and useReducer hooks marked as editable so state can
+					// cast to more specific ReducerHookState value.
+					(s as [any, any])[0] = value;
 					c.forceUpdate();
 				}
 			}

--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -563,7 +563,7 @@ export function createRenderer(
 			const vnode = domToVNode.get(node);
 			if (vnode) {
 				if (shouldFilter(vnode, filters, config)) {
-					let p = vnode;
+					let p: VNode | null = vnode;
 					let found = null;
 					while ((p = getVNodeParent(p)) != null) {
 						if (!shouldFilter(p, filters, config)) {
@@ -699,7 +699,8 @@ export function createRenderer(
 				const c = getComponent(vnode);
 				if (c) {
 					const s = getHookState(c, index);
-					s[0] = value;
+					// TODO: How do we know it's okay to assign like this? Hook state varies.
+					(s as any)[0] = value;
 					c.forceUpdate();
 				}
 			}

--- a/src/adapter/10/renderer/renderReasons.ts
+++ b/src/adapter/10/renderer/renderReasons.ts
@@ -5,6 +5,8 @@ import {
 	getStatefulHookValue,
 	isUseReducerOrState,
 	getVNodeParent,
+	getStartTime,
+	getEndTime,
 } from "../vnode";
 import { ID } from "../../../view/store/types";
 
@@ -109,8 +111,8 @@ export function getRenderReason(
 	const parent = getVNodeParent(next);
 	if (
 		parent != null &&
-		(next.startTime || 0) >= parent.startTime &&
-		(next.endTime || 0) <= parent.endTime
+		getStartTime(next) >= getStartTime(parent) &&
+		getEndTime(next) <= getEndTime(parent)
 	) {
 		return createReason(RenderReason.PARENT_UPDATE, null);
 	}


### PR DESCRIPTION
Add return type to all helpers and fix up a couple of callsites to either use a precise call or note and cast.

Use cast to internal preact types in preference to any for accessing private attributes, where possible. Older aliases still require any.

As an experiment, seems like this might be somewhat useful and not too much magic required? Note the `TODO` that I wasn't sure on the answer from glancing over the preact hook code.