### PR TITLE
Fix Suspense nodes not recognized

### DIFF
--- a/.changeset/few-games-tease.md
+++ b/.changeset/few-games-tease.md
@@ -1,0 +1,5 @@
+---
+"preact-devtools": patch
+---
+
+Fix Suspense nodes not being detected.

--- a/src/adapter/10/renderer.ts
+++ b/src/adapter/10/renderer.ts
@@ -289,7 +289,16 @@ export function resetChildren(
 	if (!children.length) return;
 
 	const next = getFilteredChildren(vnode, filters, config);
-	if (next.length < 2) return;
+
+	// Suspense internals mutate child outside of the standard render cycle.
+	// This leads to stale children on the devtools ends. To work around that
+	// We'll always reset the children of a Suspense vnode.
+	let forceReorder = false;
+	if (isSuspenseVNode(vnode)) {
+		forceReorder = true;
+	}
+
+	if (!forceReorder && next.length < 2) return;
 
 	commit.operations.push(
 		MsgTypes.REORDER_CHILDREN,

--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -57,8 +57,8 @@ export function hasDom(x: any): boolean {
  */
 export function isSuspenseVNode(vnode: VNode): boolean {
 	const c = getComponent(vnode) as any;
-	// FIXME: Mangling of `_childDidSuspend` is not stable in Preact
-	return c != null && c._childDidSuspend;
+	// FYI: Mangling of `_childDidSuspend` is not stable in Preact < 10.3.0
+	return c != null && !!(c._childDidSuspend || c.__c);
 }
 
 /**
@@ -184,6 +184,16 @@ export function getDisplayName(vnode: VNode, config: RendererConfig10): string {
 				if (ctx && ctx.displayName) {
 					return `${ctx.displayName}.Provider`;
 				}
+			}
+
+			if (isSuspenseVNode(vnode)) {
+				return "Suspense";
+			}
+
+			// Preact 10.4.1 uses a raw Component as a child for Suspense
+			// by doing `createElement(Component, ...);`
+			if (type === config.Component) {
+				return "Component";
 			}
 		}
 

--- a/test-e2e/fixtures/suspense.js
+++ b/test-e2e/fixtures/suspense.js
@@ -1,0 +1,42 @@
+const { h, render } = preact;
+const { Suspense } = preactCompat;
+const { useMemo } = preactHooks;
+
+function withDelay(ms) {
+	useMemo(() => {
+		let done = false;
+		const promise = new Promise(resolve => setTimeout(resolve, ms)).then(() => {
+			done = true;
+		});
+		return () => {
+			if (!done) {
+				throw promise;
+			}
+		};
+	}, [])();
+}
+
+function Block(props) {
+	const style = "padding: 2rem; background: " + props.background + ";";
+	return html`
+		<div data-testid=${props.id} style=${style}>${props.children}<//>
+	`;
+}
+
+function Delayed(props) {
+	withDelay(props.waitMs);
+	return html` <${Block} id="delayed" background="cadetblue" /> `;
+}
+
+function Shortly() {
+	const fallback = html` <${Block} id="skeleton" background="grey" /> `;
+	return html`
+		<${Block} id="container" background="black">
+			<${Suspense} fallback=${fallback}>
+				<${Delayed} waitMs=${500} />
+			<//>
+		<//>
+	`;
+}
+
+render(h(Shortly), document.getElementById("app"));

--- a/test-e2e/fixtures/suspense.js
+++ b/test-e2e/fixtures/suspense.js
@@ -25,13 +25,13 @@ function Block(props) {
 
 function Delayed(props) {
 	withDelay(props.waitMs);
-	return html` <${Block} id="delayed" background="cadetblue" /> `;
+	return html`<${Block} id="delayed" background="blueviolet" />`;
 }
 
 function Shortly() {
-	const fallback = html` <${Block} id="skeleton" background="grey" /> `;
+	const fallback = html`<${Block} id="skeleton" background="grey" />`;
 	return html`
-		<${Block} id="container" background="black">
+		<${Block} id="container" background="#ccc">
 			<${Suspense} fallback=${fallback}>
 				<${Delayed} waitMs=${500} />
 			<//>

--- a/test-e2e/test-utils.ts
+++ b/test-e2e/test-utils.ts
@@ -244,6 +244,15 @@ export async function enableHOCFilter(page: Page) {
 	}
 }
 
+// TODO: This might clash with windowing
+export async function getTreeViewItemNames(page: Page) {
+	return await page.evaluate(() => {
+		return Array.from(
+			document.querySelectorAll('[data-testid="tree-item"]'),
+		).map(el => el.getAttribute("data-name"));
+	});
+}
+
 // This injects a box into the page that moves with the mouse;
 // Useful for debugging
 export async function installMouseHelper(page: Page) {

--- a/test-e2e/tests/highlight-margin.test.ts
+++ b/test-e2e/tests/highlight-margin.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { wait } from "pentf/utils";
 import { Page } from "puppeteer";
 
-export const description = "Hihglight overlay should account for margin";
+export const description = "Highlight overlay should account for margin";
 
 function getHighlightSize(page: Page) {
 	return getSize(page, "#preact-devtools-highlighter > div");

--- a/test-e2e/tests/highlight-suspense.test.ts
+++ b/test-e2e/tests/highlight-suspense.test.ts
@@ -1,29 +1,24 @@
 import { newTestPage, getSize } from "../test-utils";
 import { expect } from "chai";
 import { wait } from "pentf/utils";
-
+import { waitForTestId } from "pentf/browser_utils";
 import type { Page } from "puppeteer";
-
-export const description = "Display and highlighting of Suspense in devtools";
 
 function getHighlightSize(page: Page): unknown {
 	return getSize(page, "#preact-devtools-highlighter > div");
 }
 
-export async function run(config: any): Promise<void> {
+export const description = "Highlight Suspense nodes without crashing";
+export async function run(config: any) {
 	const { page, devtools } = await newTestPage(config, "suspense");
 
-	// TODO: would expect tree-item list to be:
-	//   ["Block", "Shortly", "Suspense", "Delayed", "Block"]
-	// but is actually:
-	//   ["Block", "Shortly", "Suspense", "m"]
+	await waitForTestId(devtools, "tree-item");
 
 	await devtools.hover('[data-testid="tree-item"][data-name="Suspense"]');
 	// Wait for possible flickering to occur
 	await wait(1000);
-	const sizeOnPage = await getSize(page, '[data-testid="container"]');
+
+	const sizeOnPage = await getSize(page, '[data-testid="delayed"]');
 	const sizeOfHighlight = await getHighlightSize(page);
 	expect(sizeOfHighlight).to.eql(sizeOnPage);
-
-	// TODO: expect size of delayed child to be correctly shown
 }

--- a/test-e2e/tests/highlight-suspense.test.ts
+++ b/test-e2e/tests/highlight-suspense.test.ts
@@ -1,0 +1,29 @@
+import { newTestPage, getSize } from "../test-utils";
+import { expect } from "chai";
+import { wait } from "pentf/utils";
+
+import type { Page } from "puppeteer";
+
+export const description = "Display and highlighting of Suspense in devtools";
+
+function getHighlightSize(page: Page): unknown {
+	return getSize(page, "#preact-devtools-highlighter > div");
+}
+
+export async function run(config: any): Promise<void> {
+	const { page, devtools } = await newTestPage(config, "suspense");
+
+	// TODO: would expect tree-item list to be:
+	//   ["Block", "Shortly", "Suspense", "Delayed", "Block"]
+	// but is actually:
+	//   ["Block", "Shortly", "Suspense", "m"]
+
+	await devtools.hover('[data-testid="tree-item"][data-name="Suspense"]');
+	// Wait for possible flickering to occur
+	await wait(1000);
+	const sizeOnPage = await getSize(page, '[data-testid="container"]');
+	const sizeOfHighlight = await getHighlightSize(page);
+	expect(sizeOfHighlight).to.eql(sizeOnPage);
+
+	// TODO: expect size of delayed child to be correctly shown
+}

--- a/test-e2e/tests/suspense.test.ts
+++ b/test-e2e/tests/suspense.test.ts
@@ -14,7 +14,7 @@ export async function run(config: any) {
 		"Shortly",
 		"Block",
 		"Suspense",
-		"Component",
+		"Component", // <10.4.5, newer versions use a Fragment
 		"Block",
 	]);
 
@@ -25,7 +25,7 @@ export async function run(config: any) {
 				"Shortly",
 				"Block",
 				"Suspense",
-				"Component",
+				"Component", // <10.4.5, newer versions use a Fragment
 				"Delayed",
 				"Block",
 			]);

--- a/test-e2e/tests/suspense.test.ts
+++ b/test-e2e/tests/suspense.test.ts
@@ -1,0 +1,35 @@
+import { newTestPage, getTreeViewItemNames } from "../test-utils";
+import { expect } from "chai";
+import { waitForTestId } from "pentf/browser_utils";
+import { assertEventually } from "pentf/assert_utils";
+
+export const description = "Display Suspense in tree view";
+export async function run(config: any) {
+	const { devtools } = await newTestPage(config, "suspense");
+
+	await waitForTestId(devtools, "tree-item");
+
+	const items = await getTreeViewItemNames(devtools);
+	expect(items).to.deep.equal([
+		"Shortly",
+		"Block",
+		"Suspense",
+		"Component",
+		"Block",
+	]);
+
+	await assertEventually(
+		async () => {
+			const items = await getTreeViewItemNames(devtools);
+			expect(items).to.deep.equal([
+				"Shortly",
+				"Block",
+				"Suspense",
+				"Component",
+				"Delayed",
+				"Block",
+			]);
+		},
+		{ crashOnError: false, timeout: 5000 },
+	);
+}


### PR DESCRIPTION
This PR builds on the work in #260.

With these changes `Suspense` nodes are now correctly detected and displayed. Note that Preact versions <10.4.5 used a raw `Component` class as a wrapper which is visible here. Newer Preact versions use a `Fragment` for that which we'll filter out automatically.

There was one oddity in regards to the children of a `Suspense` vnode. They can't be cached as Preact modifies them outside the usual render cycle.