### PR TITLE
Add support for suspending components

### DIFF
--- a/.changeset/stale-clouds-rescue.md
+++ b/.changeset/stale-clouds-rescue.md
@@ -1,0 +1,5 @@
+---
+"preact-devtools": patch
+---
+
+Add support for suspending Suspense components

--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -217,3 +217,30 @@ export function getNextState<S>(c: Component): S {
 export function setNextState<S>(c: Component, value: S): S {
 	return ((c as IComponent)._nextState = (c as any).__s = value);
 }
+
+export function getSuspenseStateKey(c: Component<any, any>) {
+	if ("_suspended" in c.state) {
+		return "_suspended";
+	} else if ("__e" in c.state) {
+		return "__e";
+	}
+
+	// This is a bit whacky, but property name mangling is unsafe in
+	// Preact <10.4.9
+	const keys = Object.keys(c.state);
+	if (keys.length > 0) {
+		return keys[0];
+	}
+
+	return null;
+}
+
+export function createSuspenseState(vnode: VNode, suspended: boolean) {
+	const c = getComponent(vnode) as Component<any, any>;
+	const key = getSuspenseStateKey(c);
+	if (c && key) {
+		return { [key]: suspended };
+	}
+
+	return {};
+}

--- a/src/adapter/MultiRenderer.ts
+++ b/src/adapter/MultiRenderer.ts
@@ -21,6 +21,9 @@ export function createMultiRenderer(
 	renderers: Map<number, Renderer>,
 ): Renderer {
 	return {
+		suspend(id, active) {
+			renderers.forEach(r => r.suspend && r.suspend(id, active));
+		},
 		refresh() {
 			renderers.forEach(r => r.refresh && r.refresh());
 		},

--- a/src/adapter/adapter/adapter.ts
+++ b/src/adapter/adapter/adapter.ts
@@ -33,6 +33,9 @@ export interface InspectData {
 	hooks: PropData[] | null;
 	props: Record<string, any> | null;
 	state: Record<string, any> | null;
+	canSuspend: boolean;
+	/** Only Suspense components have this */
+	suspended: boolean;
 }
 
 export function createAdapter(port: PortPageHook, renderer: Renderer) {
@@ -198,6 +201,12 @@ export function createAdapter(port: PortPageHook, renderer: Renderer) {
 					: type;
 		} else {
 			hook.$type = null;
+		}
+	});
+
+	listen("suspend", data => {
+		if (renderer.suspend) {
+			renderer.suspend(data.id, data.active);
 		}
 	});
 }

--- a/src/adapter/events/events.test.ts
+++ b/src/adapter/events/events.test.ts
@@ -230,6 +230,8 @@ describe("applyEvent", () => {
 			props: null,
 			state: null,
 			type: "asd",
+			canSuspend: false,
+			suspended: false,
 		};
 
 		const data = fromSnapshot([
@@ -255,6 +257,8 @@ describe("applyEvent", () => {
 			props: null,
 			state: null,
 			type: "asd",
+			canSuspend: false,
+			suspended: false,
 		};
 
 		store.sidebar.props.uncollapsed.$ = ["a", "b", "c"];

--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -53,6 +53,7 @@ export interface DevtoolEvents {
 	init: null;
 	refresh: null;
 	disconnect: null;
+	suspend: { id: ID; active: boolean };
 }
 export type EmitFn = <K extends keyof DevtoolEvents>(
 	name: K,

--- a/src/adapter/renderer.ts
+++ b/src/adapter/renderer.ts
@@ -36,4 +36,7 @@ export interface Renderer {
 
 	// Hooks
 	updateHook?(id: ID, index: number, value: any): void; // V3
+
+	// Component actions
+	suspend?(id: ID, active: boolean): void; // V4
 }

--- a/src/view/components/ComponentName/index.tsx
+++ b/src/view/components/ComponentName/index.tsx
@@ -3,7 +3,7 @@ import s from "./ComponentName.css";
 
 export function ComponentName(props: { children: any }) {
 	return (
-		<span class={s.title}>
+		<span class={s.title} data-testid="inspect-component-name">
 			{props.children ? (
 				<Fragment>
 					<span class={s.nameCh}>&lt;</span>

--- a/src/view/components/icons.tsx
+++ b/src/view/components/icons.tsx
@@ -299,3 +299,16 @@ export function CodeIcon({ size = "s" }: Props) {
 		</Fragment>,
 	);
 }
+
+export function SuspendIcon({ size = "s" }: Props) {
+	return createSvgIcon(
+		size,
+		<Fragment>
+			<path d="M0 0h24v24H0z" fill="none" />
+			<path
+				d="M15 1H9v2h6V1zm-4 13h2V8h-2v6zm8.03-6.61l1.42-1.42c-.43-.51-.9-.99-1.41-1.41l-1.42 1.42C16.07 4.74 14.12 4 12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9 9-4.03 9-9c0-2.12-.74-4.07-1.97-5.61zM12 20c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"
+				fill="currentColor"
+			/>
+		</Fragment>,
+	);
+}

--- a/src/view/components/sidebar/SidebarActions.tsx
+++ b/src/view/components/sidebar/SidebarActions.tsx
@@ -2,7 +2,7 @@ import { h, Fragment } from "preact";
 import s from "./Sidebar.css";
 import { Actions } from "../Actions";
 import { IconBtn } from "../IconBtn";
-import { BugIcon, InspectNativeIcon, CodeIcon } from "../icons";
+import { BugIcon, InspectNativeIcon, CodeIcon, SuspendIcon } from "../icons";
 import { useStore, useEmitter, useObserver } from "../../store/react-bindings";
 import { useCallback } from "preact/hooks";
 import { ComponentName } from "../ComponentName";
@@ -31,6 +31,25 @@ export function SidebarActions() {
 		node.type !== DevNodeType.Group &&
 		node.type !== DevNodeType.Element;
 
+	const suspense = useObserver(() => {
+		const state = {
+			canSuspend: false,
+			suspended: false,
+		};
+
+		if (store.inspectData.$) {
+			state.canSuspend = store.inspectData.$.canSuspend;
+			state.suspended = store.inspectData.$.suspended;
+		}
+
+		return state;
+	});
+	const onSuspend = useCallback(() => {
+		if (node) {
+			emit("suspend", { id: node.id, active: !suspense.suspended });
+		}
+	}, [node, suspense]);
+
 	return (
 		<Actions class={s.actions}>
 			<ComponentName>{node && node.name}</ComponentName>
@@ -38,6 +57,16 @@ export function SidebarActions() {
 			<div class={s.iconActions}>
 				{node && (
 					<Fragment>
+						{suspense.canSuspend && (
+							<IconBtn
+								title="Suspend Tree"
+								testId="suspend-action"
+								active={suspense.suspended}
+								onClick={onSuspend}
+							>
+								<SuspendIcon />
+							</IconBtn>
+						)}
 						<IconBtn
 							title="Show matching DOM element"
 							onClick={inspectHostNode}

--- a/test-e2e/tests/suspense-toggle.test.ts
+++ b/test-e2e/tests/suspense-toggle.test.ts
@@ -1,0 +1,69 @@
+import { newTestPage, getTreeViewItemNames } from "../test-utils";
+import { expect } from "chai";
+import {
+	assertNotTestId,
+	clickSelector,
+	clickTestId,
+	getAttribute,
+	getText,
+} from "pentf/browser_utils";
+import { assertEventually } from "pentf/assert_utils";
+
+export const description = "Display Suspense in tree view";
+export async function run(config: any) {
+	const { devtools } = await newTestPage(config, "suspense");
+
+	await devtools.waitForSelector(
+		'[data-testid="tree-item"][data-name="Delayed"]',
+	);
+
+	await clickSelector(
+		devtools,
+		'[data-testid="tree-item"][data-name="Delayed"]',
+	);
+
+	await clickTestId(devtools, "suspend-action");
+
+	await assertEventually(
+		async () => {
+			const items = await getTreeViewItemNames(devtools);
+			expect(items).to.deep.equal([
+				"Shortly",
+				"Block",
+				"Suspense",
+				"Component", // <10.4.5, newer versions use a Fragment
+				"Block",
+			]);
+			return true;
+		},
+		{ crashOnError: false, timeout: 2000 },
+	);
+
+	const selected = await getAttribute(
+		devtools,
+		'[data-testid="tree-item"][data-selected="true"]',
+		"data-name",
+	);
+
+	expect(selected).to.equal("Suspense");
+
+	await clickSelector(
+		devtools,
+		'[data-testid="tree-item"][data-name="Shortly"]',
+		{ timeout: 2000 },
+	);
+
+	await assertEventually(
+		async () => {
+			const inspected = await getText(
+				devtools,
+				'[data-testid="inspect-component-name"]',
+			);
+			expect(inspected).to.equal("<Shortly>");
+			return true;
+		},
+		{ crashOnError: false, timeout: 2000 },
+	);
+
+	await assertNotTestId(devtools, "suspend-action", { timeout: 2000 });
+}


### PR DESCRIPTION
This PR adds a new button in the sidebar action area that can be used to suspend trees. On click it will search upwards for the nearest Suspense component and toggle the suspending state.

![Screenshot from 2020-09-22 23-53-00](https://user-images.githubusercontent.com/1062408/93941529-f5a86c00-fd2e-11ea-9293-56526ccae106.png)
