### PR TITLE
Fix Fragments not filtered out

### DIFF
--- a/.changeset/orange-numbers-vanish.md
+++ b/.changeset/orange-numbers-vanish.md
@@ -1,0 +1,5 @@
+---
+"preact-devtools": patch
+---
+
+Fix Fragments not being filtered with Preact versions other than the devtools was built with

--- a/src/adapter/10/filter.ts
+++ b/src/adapter/10/filter.ts
@@ -1,4 +1,4 @@
-import { VNode, Fragment } from "preact";
+import { VNode } from "preact";
 import { getDisplayName, getVNodeParent } from "./vnode";
 import { TypeFilterValue, FilterState } from "../adapter/filter";
 import { RendererConfig10 } from "./renderer";
@@ -25,7 +25,7 @@ export function shouldFilter(
 	if (vnode.type == null) return true;
 
 	if (typeof vnode.type === "function") {
-		if (vnode.type === Fragment && filters.type.has("fragment")) {
+		if (vnode.type === config.Fragment && filters.type.has("fragment")) {
 			const parent = getVNodeParent(vnode);
 			// Only filter non-root nodes
 			if (parent != null) return true;

--- a/test-e2e/fixtures/fragment-filter.js
+++ b/test-e2e/fixtures/fragment-filter.js
@@ -1,0 +1,14 @@
+const { render, Fragment } = preact;
+
+const css = "background: peachpuff; padding: 2rem; margin-bottom: 1rem;";
+
+function Foo() {
+	return html`<div style=${css}>A</div>`;
+}
+
+render(
+	html`<${Fragment}>
+		<${Foo} />
+	<//>`,
+	document.getElementById("app"),
+);

--- a/test-e2e/tests/filter-fragment.test.ts
+++ b/test-e2e/tests/filter-fragment.test.ts
@@ -1,0 +1,13 @@
+import { newTestPage, getTreeViewItemNames } from "../test-utils";
+import { expect } from "chai";
+
+export const description = "Fragment filter should filter Fragment nodes";
+
+export async function run(config: any) {
+	const { devtools } = await newTestPage(config, "fragment-filter", {
+		preact: "10.4.1",
+	});
+
+	const names = await getTreeViewItemNames(devtools);
+	expect(names).to.deep.equal(["Foo"]);
+}


### PR DESCRIPTION
Used the wrong `Fragment` reference in our comparisons :see_no_evil: 