### PR TITLE
Show usage info in the disabled popup

### DIFF
--- a/src/shells/shared/popup/disabled.html
+++ b/src/shells/shared/popup/disabled.html
@@ -6,10 +6,16 @@
 		<style>
 			body {
 				min-width: 20.5em;
+				font-family: sans-serif;
+			}
+      
+			code {
+				color: #673ab8;
 			}
 		</style>
 	</head>
 	<body>
 		<p>This page doesn't seem to be using Preact.</p>
+		<p>Import <code>preact/debug</code> somewhere to initialize the connection to the extension. Make sure that this import is the <strong>first import</strong> in your whole app.</p>
 	</body>
 </html>


### PR DESCRIPTION
Currently, the disabled popup looks like this (in Firefox):

<img width="408" alt="image" src="https://user-images.githubusercontent.com/2098462/99905176-8e2b8000-2ccf-11eb-89a2-1db63b2bb53a.png">

I think it could be a nice quick win if it showed a sentence to remind the user how to enable the devtools in their project:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/2098462/99905199-c0d57880-2ccf-11eb-9c3e-91b2592034d0.png">

(The sentence is taken directly from the README.md)