### PR TITLE
fix: Firefox description

### DIFF
--- a/src/shells/firefox/manifest.json
+++ b/src/shells/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Preact Developer Tools",
-	"description": "Adds debugging tools for Preact to Chrome",
+	"description": "Adds debugging tools for Preact to Firefox",
 	"version": "1.2.0",
 	"devtools_page": "panel/empty-panel.html",
 	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",


### PR DESCRIPTION
Hello, 

Noticed this when scrolling through my extensions on Firefox:

![temp](https://user-images.githubusercontent.com/33403762/100672053-fceb8780-3326-11eb-896a-c6e18669558b.PNG)

Super minor copy/paste error.