### PR TITLE
Use pagehide instead of unload

### DIFF
--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -142,8 +142,8 @@ export function createHook(port: PortPageHook): DevtoolsHook {
 		return uid;
 	};
 
-	// Delete all roots when the current frame unloads
-	window.addEventListener("unload", () => {
+	// Delete all roots when the current frame is closed
+	window.addEventListener("pagehide", () => {
 		renderers.forEach(r => {
 			if (r.clear) r.clear();
 		});


### PR DESCRIPTION
The latter has been marked as not recommended as it prevents
the browser from using in memory caches.

See: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5/Using_Firefox_1.5_caching

Fixes #275 