### PR TITLE
Add support for useDebugName hook

### DIFF
--- a/src/adapter/10/options.ts
+++ b/src/adapter/10/options.ts
@@ -9,7 +9,7 @@ import {
 	getStatefulHookValue,
 	getComponent,
 } from "./vnode";
-import { addHookStack, addDebugValue } from "./renderer/hooks";
+import { addHookStack, addDebugValue, addHookName } from "./renderer/hooks";
 import { HookType } from "../../constants";
 
 /**
@@ -50,7 +50,9 @@ export function setupOptions(
 	const prevBeforeDiff = o._diff || o.__b;
 	const prevAfterDiff = options.diffed;
 	let prevHook = o._hook || o.__h;
-	let prevUseDebug = options.useDebugValue;
+	let prevUseDebugValue = options.useDebugValue;
+	// @ts-ignore
+	let prevHookName = options.useDebugName;
 
 	options.vnode = vnode => {
 		// Tiny performance improvement by initializing fields as doubles
@@ -74,7 +76,9 @@ export function setupOptions(
 	// parsed hooks.
 	setTimeout(() => {
 		prevHook = o._hook || o.__h;
-		prevUseDebug = options.useDebugValue;
+		prevUseDebugValue = options.useDebugValue;
+		// @ts-ignore
+		prevHookName = options._addHookName || options.__a;
 
 		o._hook = o.__h = (c: Component, index: number, type: number) => {
 			const s = getStatefulHooks(c);
@@ -98,7 +102,13 @@ export function setupOptions(
 		options.useDebugValue = (value: any) => {
 			addHookStack(HookType.useDebugValue);
 			addDebugValue(value);
-			if (prevUseDebug) prevUseDebug(value);
+			if (prevUseDebugValue) prevUseDebugValue(value);
+		};
+
+		// @ts-ignore
+		options._addHookName = options.__a = (name: string | number) => {
+			addHookName(name);
+			if (prevHookName) prevHookName(name);
 		};
 	}, 100);
 
@@ -145,6 +155,6 @@ export function setupOptions(
 		o._diff = o.__b = prevBeforeDiff;
 		options.vnode = prevVNodeHook;
 		o._hook = o.__h = prevHook;
-		options.useDebugValue = prevUseDebug;
+		options.useDebugValue = prevUseDebugValue;
 	};
 }

--- a/src/adapter/10/renderer/hooks.ts
+++ b/src/adapter/10/renderer/hooks.ts
@@ -31,6 +31,12 @@ let hookLog: HookData[] = [];
 let inspectingHooks = false;
 let ancestorName = "unknown";
 const debugValues = new Map<string, string>();
+let debugNames: string[] = [];
+
+export function addHookName(name: any) {
+	if (!inspectingHooks) return;
+	debugNames.push(String(name));
+}
 
 export function addDebugValue(value: any) {
 	if (!inspectingHooks) return;
@@ -139,7 +145,14 @@ export function parseHookData(
 				let children: string[] = [];
 				let nodeType: PropDataType = "undefined";
 				const depth = hook.stack.length - i - 1;
-				const name = isNative ? type : frame.name;
+				let name = isNative ? type : frame.name;
+				if (
+					(debugNames.length > 0 && hook.type === HookType.useState) ||
+					hook.type === HookType.useRef ||
+					hook.type === HookType.useReducer
+				) {
+					name = debugNames.pop()!;
+				}
 
 				if (debugValues.has(id)) {
 					value = debugValues.get(id);
@@ -221,6 +234,7 @@ export function inspectHooks(
 	inspectingHooks = true;
 	hookLog = [];
 	debugValues.clear();
+	debugNames = [];
 	ancestorName = parseStackTrace(new Error().stack!)[0].name;
 
 	const c = getComponent(vnode)!;

--- a/test-e2e/fixtures/hooks-name.js
+++ b/test-e2e/fixtures/hooks-name.js
@@ -1,0 +1,96 @@
+const { h, render } = preact;
+const {
+	useState,
+	useEffect,
+	useReducer,
+	useCallback,
+	useRef,
+	useLayoutEffect,
+} = preactHooks;
+const { addHookName } = preactDevtools;
+
+function Display(props) {
+	return html` <div data-testid=${props.testId}>Counter: ${props.value}</div> `;
+}
+
+function Counter() {
+	const [v, set] = addHookName(useState(0), "customState");
+
+	return html`
+		<div style="padding: 2rem;">
+			<${Display} value=${v} testId="result" />
+			<button onClick=${() => set(v + 1)}>Increment</button>
+		</div>
+	`;
+}
+
+function CounterCallback() {
+	const [v, set] = addHookName(useState(0), "counterState");
+	const cb = useCallback(() => set(v + 1), [v]);
+
+	return html`
+		<div style="padding: 2rem;">
+			<${Display} value=${v} testId="callback-result" />
+			<button onClick=${cb}>Increment</button>
+		</div>
+	`;
+}
+
+function RefComponent() {
+	const v = addHookName(useRef(0), "customRef");
+	return html`<p>Ref: ${v.current}</p>`;
+}
+
+function ReducerComponent() {
+	const [v] = addHookName(
+		useReducer(a => a, "foo"),
+		"customReducer",
+	);
+	return html`<p>Reducer: ${v}</p>`;
+}
+
+// Invalid wrappings
+function CallbackOnly() {
+	const cb = addHookName(
+		useCallback(() => 2, []),
+		"invalid",
+	);
+
+	return html`
+		<div style="padding: 2rem;">
+			<button onClick=${cb}>Callback: should be invalid</button>
+		</div>
+	`;
+}
+
+function LayoutEffect() {
+	addHookName(
+		useLayoutEffect(() => {}, []),
+		"invalid2",
+	);
+
+	return html`<p>LayoutEffect: should be invalid</p>`;
+}
+
+function Effect() {
+	addHookName(
+		useEffect(() => {}, []),
+		"invalid3",
+	);
+
+	return html`<p>effect: should be invalid</p>`;
+}
+
+render(
+	html`
+		<${Counter} />
+		<${CounterCallback} />
+		<${ReducerComponent} />
+		<${RefComponent} />
+		<p>Invalid</p>
+		<${CallbackOnly} />
+		<${LayoutEffect} />
+		<${Effect} />
+	`,
+	document.getElementById("app"),
+);

--- a/test-e2e/fixtures/vendor/preact/use-debug-name/preact.js
+++ b/test-e2e/fixtures/vendor/preact/use-debug-name/preact.js
@@ -1,0 +1,624 @@
+!(function (n, l) {
+	"object" == typeof exports && "undefined" != typeof module
+		? l(exports)
+		: "function" == typeof define && define.amd
+		? define(["exports"], l)
+		: l((n.preact = {}));
+})(this, function (n) {
+	var l,
+		u,
+		i,
+		t,
+		o,
+		f,
+		r = {},
+		e = [],
+		c = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;
+	function s(n, l) {
+		for (var u in l) n[u] = l[u];
+		return n;
+	}
+	function a(n) {
+		var l = n.parentNode;
+		l && l.removeChild(n);
+	}
+	function v(n, l, u) {
+		var i,
+			t,
+			o,
+			f = arguments,
+			r = {};
+		for (o in l)
+			"key" == o ? (i = l[o]) : "ref" == o ? (t = l[o]) : (r[o] = l[o]);
+		if (arguments.length > 3)
+			for (u = [u], o = 3; o < arguments.length; o++) u.push(f[o]);
+		if (
+			(null != u && (r.children = u),
+			"function" == typeof n && null != n.defaultProps)
+		)
+			for (o in n.defaultProps) void 0 === r[o] && (r[o] = n.defaultProps[o]);
+		return h(n, r, i, t, null);
+	}
+	function h(n, u, i, t, o) {
+		var f = {
+			type: n,
+			props: u,
+			key: i,
+			ref: t,
+			__k: null,
+			__: null,
+			__b: 0,
+			__e: null,
+			__d: void 0,
+			__c: null,
+			__h: null,
+			constructor: void 0,
+			__v: null == o ? ++l.__v : o,
+		};
+		return null != l.vnode && l.vnode(f), f;
+	}
+	function y(n) {
+		return n.children;
+	}
+	function p(n, l) {
+		(this.props = n), (this.context = l);
+	}
+	function d(n, l) {
+		if (null == l) return n.__ ? d(n.__, n.__.__k.indexOf(n) + 1) : null;
+		for (var u; l < n.__k.length; l++)
+			if (null != (u = n.__k[l]) && null != u.__e) return u.__e;
+		return "function" == typeof n.type ? d(n) : null;
+	}
+	function _(n) {
+		var l, u;
+		if (null != (n = n.__) && null != n.__c) {
+			for (n.__e = n.__c.base = null, l = 0; l < n.__k.length; l++)
+				if (null != (u = n.__k[l]) && null != u.__e) {
+					n.__e = n.__c.base = u.__e;
+					break;
+				}
+			return _(n);
+		}
+	}
+	function k(n) {
+		((!n.__d && (n.__d = !0) && i.push(n) && !m.__r++) ||
+			o !== l.debounceRendering) &&
+			((o = l.debounceRendering) || t)(m);
+	}
+	function m() {
+		for (var n; (m.__r = i.length); )
+			(n = i.sort(function (n, l) {
+				return n.__v.__b - l.__v.__b;
+			})),
+				(i = []),
+				n.some(function (n) {
+					var l, u, i, t, o, f;
+					n.__d &&
+						((o = (t = (l = n).__v).__e),
+						(f = l.__P) &&
+							((u = []),
+							((i = s({}, t)).__v = t.__v + 1),
+							j(
+								f,
+								t,
+								i,
+								l.__n,
+								void 0 !== f.ownerSVGElement,
+								null != t.__h ? [o] : null,
+								u,
+								null == o ? d(t) : o,
+								t.__h,
+							),
+							H(u, t),
+							t.__e != o && _(t)));
+				});
+	}
+	function b(n, l, u, i, t, o, f, c, s, a) {
+		var v,
+			p,
+			_,
+			k,
+			m,
+			b,
+			x,
+			A = (i && i.__k) || e,
+			P = A.length;
+		for (u.__k = [], v = 0; v < l.length; v++)
+			if (
+				null !=
+				(k = u.__k[v] =
+					null == (k = l[v]) || "boolean" == typeof k
+						? null
+						: "string" == typeof k || "number" == typeof k
+						? h(null, k, null, null, k)
+						: Array.isArray(k)
+						? h(y, { children: k }, null, null, null)
+						: k.__b > 0
+						? h(k.type, k.props, k.key, null, k.__v)
+						: k)
+			) {
+				if (
+					((k.__ = u),
+					(k.__b = u.__b + 1),
+					null === (_ = A[v]) || (_ && k.key == _.key && k.type === _.type))
+				)
+					A[v] = void 0;
+				else
+					for (p = 0; p < P; p++) {
+						if ((_ = A[p]) && k.key == _.key && k.type === _.type) {
+							A[p] = void 0;
+							break;
+						}
+						_ = null;
+					}
+				j(n, k, (_ = _ || r), t, o, f, c, s, a),
+					(m = k.__e),
+					(p = k.ref) &&
+						_.ref != p &&
+						(x || (x = []),
+						_.ref && x.push(_.ref, null, k),
+						x.push(p, k.__c || m, k)),
+					null != m
+						? (null == b && (b = m),
+						  "function" == typeof k.type && null != k.__k && k.__k === _.__k
+								? (k.__d = s = g(k, s, n))
+								: (s = w(n, k, _, A, m, s)),
+						  a || "option" !== u.type
+								? "function" == typeof u.type && (u.__d = s)
+								: (n.value = ""))
+						: s && _.__e == s && s.parentNode != n && (s = d(_));
+			}
+		for (u.__e = b, v = P; v--; )
+			null != A[v] &&
+				("function" == typeof u.type &&
+					null != A[v].__e &&
+					A[v].__e == u.__d &&
+					(u.__d = d(i, v + 1)),
+				I(A[v], A[v]));
+		if (x) for (v = 0; v < x.length; v++) z(x[v], x[++v], x[++v]);
+	}
+	function g(n, l, u) {
+		var i, t;
+		for (i = 0; i < n.__k.length; i++)
+			(t = n.__k[i]) &&
+				((t.__ = n),
+				(l =
+					"function" == typeof t.type
+						? g(t, l, u)
+						: w(u, t, t, n.__k, t.__e, l)));
+		return l;
+	}
+	function w(n, l, u, i, t, o) {
+		var f, r, e;
+		if (void 0 !== l.__d) (f = l.__d), (l.__d = void 0);
+		else if (null == u || t != o || null == t.parentNode)
+			n: if (null == o || o.parentNode !== n) n.appendChild(t), (f = null);
+			else {
+				for (r = o, e = 0; (r = r.nextSibling) && e < i.length; e += 2)
+					if (r == t) break n;
+				n.insertBefore(t, o), (f = o);
+			}
+		return void 0 !== f ? f : t.nextSibling;
+	}
+	function x(n, l, u, i, t) {
+		var o;
+		for (o in u)
+			"children" === o || "key" === o || o in l || P(n, o, null, u[o], i);
+		for (o in l)
+			(t && "function" != typeof l[o]) ||
+				"children" === o ||
+				"key" === o ||
+				"value" === o ||
+				"checked" === o ||
+				u[o] === l[o] ||
+				P(n, o, l[o], u[o], i);
+	}
+	function A(n, l, u) {
+		"-" === l[0]
+			? n.setProperty(l, u)
+			: (n[l] =
+					null == u ? "" : "number" != typeof u || c.test(l) ? u : u + "px");
+	}
+	function P(n, l, u, i, t) {
+		var o;
+		n: if ("style" === l)
+			if ("string" == typeof u) n.style.cssText = u;
+			else {
+				if (("string" == typeof i && (n.style.cssText = i = ""), i))
+					for (l in i) (u && l in u) || A(n.style, l, "");
+				if (u) for (l in u) (i && u[l] === i[l]) || A(n.style, l, u[l]);
+			}
+		else if ("o" === l[0] && "n" === l[1])
+			(o = l !== (l = l.replace(/Capture$/, ""))),
+				(l = l.toLowerCase() in n ? l.toLowerCase().slice(2) : l.slice(2)),
+				n.l || (n.l = {}),
+				(n.l[l + o] = u),
+				u
+					? i || n.addEventListener(l, o ? $ : C, o)
+					: n.removeEventListener(l, o ? $ : C, o);
+		else if ("dangerouslySetInnerHTML" !== l) {
+			if (t) l = l.replace(/xlink[H:h]/, "h").replace(/sName$/, "s");
+			else if (
+				"href" !== l &&
+				"list" !== l &&
+				"form" !== l &&
+				"download" !== l &&
+				l in n
+			)
+				try {
+					n[l] = null == u ? "" : u;
+					break n;
+				} catch (n) {}
+			"function" == typeof u ||
+				(null != u && (!1 !== u || ("a" === l[0] && "r" === l[1]))
+					? n.setAttribute(l, u)
+					: n.removeAttribute(l));
+		}
+	}
+	function C(n) {
+		this.l[n.type + !1](l.event ? l.event(n) : n);
+	}
+	function $(n) {
+		this.l[n.type + !0](l.event ? l.event(n) : n);
+	}
+	function j(n, u, i, t, o, f, r, e, c) {
+		var a,
+			v,
+			h,
+			d,
+			_,
+			k,
+			m,
+			g,
+			w,
+			x,
+			A,
+			P = u.type;
+		if (void 0 !== u.constructor) return null;
+		null != i.__h &&
+			((c = i.__h), (e = u.__e = i.__e), (u.__h = null), (f = [e])),
+			(a = l.__b) && a(u);
+		try {
+			n: if ("function" == typeof P) {
+				if (
+					((g = u.props),
+					(w = (a = P.contextType) && t[a.__c]),
+					(x = a ? (w ? w.props.value : a.__) : t),
+					i.__c
+						? (m = (v = u.__c = i.__c).__ = v.__E)
+						: ("prototype" in P && P.prototype.render
+								? (u.__c = v = new P(g, x))
+								: ((u.__c = v = new p(g, x)),
+								  (v.constructor = P),
+								  (v.render = L)),
+						  w && w.sub(v),
+						  (v.props = g),
+						  v.state || (v.state = {}),
+						  (v.context = x),
+						  (v.__n = t),
+						  (h = v.__d = !0),
+						  (v.__h = [])),
+					null == v.__s && (v.__s = v.state),
+					null != P.getDerivedStateFromProps &&
+						(v.__s == v.state && (v.__s = s({}, v.__s)),
+						s(v.__s, P.getDerivedStateFromProps(g, v.__s))),
+					(d = v.props),
+					(_ = v.state),
+					h)
+				)
+					null == P.getDerivedStateFromProps &&
+						null != v.componentWillMount &&
+						v.componentWillMount(),
+						null != v.componentDidMount && v.__h.push(v.componentDidMount);
+				else {
+					if (
+						(null == P.getDerivedStateFromProps &&
+							g !== d &&
+							null != v.componentWillReceiveProps &&
+							v.componentWillReceiveProps(g, x),
+						(!v.__e &&
+							null != v.shouldComponentUpdate &&
+							!1 === v.shouldComponentUpdate(g, v.__s, x)) ||
+							u.__v === i.__v)
+					) {
+						(v.props = g),
+							(v.state = v.__s),
+							u.__v !== i.__v && (v.__d = !1),
+							(v.__v = u),
+							(u.__e = i.__e),
+							(u.__k = i.__k),
+							v.__h.length && r.push(v);
+						break n;
+					}
+					null != v.componentWillUpdate && v.componentWillUpdate(g, v.__s, x),
+						null != v.componentDidUpdate &&
+							v.__h.push(function () {
+								v.componentDidUpdate(d, _, k);
+							});
+				}
+				(v.context = x),
+					(v.props = g),
+					(v.state = v.__s),
+					(a = l.__r) && a(u),
+					(v.__d = !1),
+					(v.__v = u),
+					(v.__P = n),
+					(a = v.render(v.props, v.state, v.context)),
+					(v.state = v.__s),
+					null != v.getChildContext && (t = s(s({}, t), v.getChildContext())),
+					h ||
+						null == v.getSnapshotBeforeUpdate ||
+						(k = v.getSnapshotBeforeUpdate(d, _)),
+					(A =
+						null != a && a.type === y && null == a.key ? a.props.children : a),
+					b(n, Array.isArray(A) ? A : [A], u, i, t, o, f, r, e, c),
+					(v.base = u.__e),
+					(u.__h = null),
+					v.__h.length && r.push(v),
+					m && (v.__E = v.__ = null),
+					(v.__e = !1);
+			} else null == f && u.__v === i.__v ? ((u.__k = i.__k), (u.__e = i.__e)) : (u.__e = T(i.__e, u, i, t, o, f, r, c));
+			(a = l.diffed) && a(u);
+		} catch (n) {
+			(u.__v = null),
+				(c || null != f) &&
+					((u.__e = e), (u.__h = !!c), (f[f.indexOf(e)] = null)),
+				l.__e(n, u, i);
+		}
+	}
+	function H(n, u) {
+		l.__c && l.__c(u, n),
+			n.some(function (u) {
+				try {
+					(n = u.__h),
+						(u.__h = []),
+						n.some(function (n) {
+							n.call(u);
+						});
+				} catch (n) {
+					l.__e(n, u.__v);
+				}
+			});
+	}
+	function T(n, l, u, i, t, o, f, c) {
+		var s,
+			v,
+			h,
+			y,
+			p,
+			d = u.props,
+			_ = l.props,
+			k = l.type;
+		if (("svg" === k && (t = !0), null != o))
+			for (s = 0; s < o.length; s++)
+				if (null != (v = o[s]) && (n == v || v.localName == k)) {
+					(n = v), (o[s] = null);
+					break;
+				}
+		if (null == n) {
+			if (null === k) return document.createTextNode(_);
+			(n = t
+				? document.createElementNS("http://www.w3.org/2000/svg", k)
+				: document.createElement(k, _.is && _)),
+				(o = null),
+				(c = !1);
+		}
+		if (null === k) d === _ || (c && n.data === _) || (n.data = _);
+		else {
+			if (
+				(null != o && (o = e.slice.call(n.childNodes)),
+				(h = (d = u.props || r).dangerouslySetInnerHTML),
+				(y = _.dangerouslySetInnerHTML),
+				!c)
+			) {
+				if (null != o)
+					for (d = {}, p = 0; p < n.attributes.length; p++)
+						d[n.attributes[p].name] = n.attributes[p].value;
+				(y || h) &&
+					((y && ((h && y.__html == h.__html) || y.__html === n.innerHTML)) ||
+						(n.innerHTML = (y && y.__html) || ""));
+			}
+			if ((x(n, _, d, t, c), y)) l.__k = [];
+			else if (
+				((s = l.props.children),
+				b(
+					n,
+					Array.isArray(s) ? s : [s],
+					l,
+					u,
+					i,
+					t && "foreignObject" !== k,
+					o,
+					f,
+					n.firstChild,
+					c,
+				),
+				null != o)
+			)
+				for (s = o.length; s--; ) null != o[s] && a(o[s]);
+			c ||
+				("value" in _ &&
+					void 0 !== (s = _.value) &&
+					(s !== n.value || ("progress" === k && !s)) &&
+					P(n, "value", s, d.value, !1),
+				"checked" in _ &&
+					void 0 !== (s = _.checked) &&
+					s !== n.checked &&
+					P(n, "checked", s, d.checked, !1));
+		}
+		return n;
+	}
+	function z(n, u, i) {
+		try {
+			"function" == typeof n ? n(u) : (n.current = u);
+		} catch (n) {
+			l.__e(n, i);
+		}
+	}
+	function I(n, u, i) {
+		var t, o, f;
+		if (
+			(l.unmount && l.unmount(n),
+			(t = n.ref) && ((t.current && t.current !== n.__e) || z(t, null, u)),
+			i || "function" == typeof n.type || (i = null != (o = n.__e)),
+			(n.__e = n.__d = void 0),
+			null != (t = n.__c))
+		) {
+			if (t.componentWillUnmount)
+				try {
+					t.componentWillUnmount();
+				} catch (n) {
+					l.__e(n, u);
+				}
+			t.base = t.__P = null;
+		}
+		if ((t = n.__k)) for (f = 0; f < t.length; f++) t[f] && I(t[f], u, i);
+		null != o && a(o);
+	}
+	function L(n, l, u) {
+		return this.constructor(n, u);
+	}
+	function M(n, u, i) {
+		var t, o, f;
+		l.__ && l.__(n, u),
+			(o = (t = "function" == typeof i) ? null : (i && i.__k) || u.__k),
+			(f = []),
+			j(
+				u,
+				(n = ((!t && i) || u).__k = v(y, null, [n])),
+				o || r,
+				r,
+				void 0 !== u.ownerSVGElement,
+				!t && i
+					? [i]
+					: o
+					? null
+					: u.firstChild
+					? e.slice.call(u.childNodes)
+					: null,
+				f,
+				!t && i ? i : o ? o.__e : u.firstChild,
+				t,
+			),
+			H(f, n);
+	}
+	(l = {
+		__e: function (n, l) {
+			for (var u, i, t; (l = l.__); )
+				if ((u = l.__c) && !u.__)
+					try {
+						if (
+							((i = u.constructor) &&
+								null != i.getDerivedStateFromError &&
+								(u.setState(i.getDerivedStateFromError(n)), (t = u.__d)),
+							null != u.componentDidCatch &&
+								(u.componentDidCatch(n), (t = u.__d)),
+							t)
+						)
+							return (u.__E = u);
+					} catch (l) {
+						n = l;
+					}
+			throw n;
+		},
+		__v: 0,
+	}),
+		(u = function (n) {
+			return null != n && void 0 === n.constructor;
+		}),
+		(p.prototype.setState = function (n, l) {
+			var u;
+			(u =
+				null != this.__s && this.__s !== this.state
+					? this.__s
+					: (this.__s = s({}, this.state))),
+				"function" == typeof n && (n = n(s({}, u), this.props)),
+				n && s(u, n),
+				null != n && this.__v && (l && this.__h.push(l), k(this));
+		}),
+		(p.prototype.forceUpdate = function (n) {
+			this.__v && ((this.__e = !0), n && this.__h.push(n), k(this));
+		}),
+		(p.prototype.render = y),
+		(i = []),
+		(t =
+			"function" == typeof Promise
+				? Promise.prototype.then.bind(Promise.resolve())
+				: setTimeout),
+		(m.__r = 0),
+		(f = 0),
+		(n.render = M),
+		(n.hydrate = function n(l, u) {
+			M(l, u, n);
+		}),
+		(n.createElement = v),
+		(n.h = v),
+		(n.Fragment = y),
+		(n.createRef = function () {
+			return { current: null };
+		}),
+		(n.isValidElement = u),
+		(n.Component = p),
+		(n.cloneElement = function (n, l, u) {
+			var i,
+				t,
+				o,
+				f = arguments,
+				r = s({}, n.props);
+			for (o in l)
+				"key" == o ? (i = l[o]) : "ref" == o ? (t = l[o]) : (r[o] = l[o]);
+			if (arguments.length > 3)
+				for (u = [u], o = 3; o < arguments.length; o++) u.push(f[o]);
+			return (
+				null != u && (r.children = u),
+				h(n.type, r, i || n.key, t || n.ref, null)
+			);
+		}),
+		(n.createContext = function (n, l) {
+			var u = {
+				__c: (l = "__cC" + f++),
+				__: n,
+				Consumer: function (n, l) {
+					return n.children(l);
+				},
+				Provider: function (n) {
+					var u, i;
+					return (
+						this.getChildContext ||
+							((u = []),
+							((i = {})[l] = this),
+							(this.getChildContext = function () {
+								return i;
+							}),
+							(this.shouldComponentUpdate = function (n) {
+								this.props.value !== n.value && u.some(k);
+							}),
+							(this.sub = function (n) {
+								u.push(n);
+								var l = n.componentWillUnmount;
+								n.componentWillUnmount = function () {
+									u.splice(u.indexOf(n), 1), l && l.call(n);
+								};
+							})),
+						n.children
+					);
+				},
+			};
+			return (u.Provider.__ = u.Consumer.contextType = u);
+		}),
+		(n.toChildArray = function n(l, u) {
+			return (
+				(u = u || []),
+				null == l ||
+					"boolean" == typeof l ||
+					(Array.isArray(l)
+						? l.some(function (l) {
+								n(l, u);
+						  })
+						: u.push(l)),
+				u
+			);
+		}),
+		(n.options = l);
+});
+//# sourceMappingURL=preact.umd.js.map

--- a/test-e2e/fixtures/vendor/preact/use-debug-name/preactCompat.js
+++ b/test-e2e/fixtures/vendor/preact/use-debug-name/preactCompat.js
@@ -1,0 +1,512 @@
+!(function (n, t) {
+	"object" == typeof exports && "undefined" != typeof module
+		? t(exports, require("preact/hooks"), require("preact"))
+		: "function" == typeof define && define.amd
+		? define(["exports", "preact/hooks", "preact"], t)
+		: t((n.preactCompat = {}), n.preactHooks, n.preact);
+})(this, function (n, t, e) {
+	function r(n, t) {
+		for (var e in t) n[e] = t[e];
+		return n;
+	}
+	function u(n, t) {
+		for (var e in n) if ("__source" !== e && !(e in t)) return !0;
+		for (var r in t) if ("__source" !== r && n[r] !== t[r]) return !0;
+		return !1;
+	}
+	function o(n) {
+		this.props = n;
+	}
+	function i(n, t) {
+		function r(n) {
+			var e = this.props.ref,
+				r = e == n.ref;
+			return (
+				!r && e && (e.call ? e(null) : (e.current = null)),
+				t ? !t(this.props, n) || !r : u(this.props, n)
+			);
+		}
+		function o(t) {
+			return (this.shouldComponentUpdate = r), e.createElement(n, t);
+		}
+		return (
+			(o.displayName = "Memo(" + (n.displayName || n.name) + ")"),
+			(o.prototype.isReactComponent = !0),
+			(o.__f = !0),
+			o
+		);
+	}
+	((o.prototype = new e.Component()).isPureReactComponent = !0),
+		(o.prototype.shouldComponentUpdate = function (n, t) {
+			return u(this.props, n) || u(this.state, t);
+		});
+	var f = e.options.__b;
+	e.options.__b = function (n) {
+		n.type && n.type.__f && n.ref && ((n.props.ref = n.ref), (n.ref = null)),
+			f && f(n);
+	};
+	var c =
+		("undefined" != typeof Symbol &&
+			Symbol.for &&
+			Symbol.for("react.forward_ref")) ||
+		3911;
+	function l(n) {
+		function t(t, e) {
+			var u = r({}, t);
+			return (
+				delete u.ref,
+				n(
+					u,
+					(e = t.ref || e) && ("object" != typeof e || "current" in e)
+						? e
+						: null,
+				)
+			);
+		}
+		return (
+			(t.$$typeof = c),
+			(t.render = t),
+			(t.prototype.isReactComponent = t.__f = !0),
+			(t.displayName = "ForwardRef(" + (n.displayName || n.name) + ")"),
+			t
+		);
+	}
+	var a = function (n, t) {
+			return null == n ? null : e.toChildArray(e.toChildArray(n).map(t));
+		},
+		s = {
+			map: a,
+			forEach: a,
+			count: function (n) {
+				return n ? e.toChildArray(n).length : 0;
+			},
+			only: function (n) {
+				var t = e.toChildArray(n);
+				if (1 !== t.length) throw "Children.only";
+				return t[0];
+			},
+			toArray: e.toChildArray,
+		},
+		h = e.options.__e;
+	function p() {
+		(this.__u = 0), (this.t = null), (this.__b = null);
+	}
+	function d(n) {
+		var t = n.__.__c;
+		return t && t.__e && t.__e(n);
+	}
+	function v(n) {
+		var t, r, u;
+		function o(o) {
+			if (
+				(t ||
+					(t = n()).then(
+						function (n) {
+							r = n.default || n;
+						},
+						function (n) {
+							u = n;
+						},
+					),
+				u)
+			)
+				throw u;
+			if (!r) throw t;
+			return e.createElement(r, o);
+		}
+		return (o.displayName = "Lazy"), (o.__f = !0), o;
+	}
+	function m() {
+		(this.u = null), (this.o = null);
+	}
+	(e.options.__e = function (n, t, e) {
+		if (n.then)
+			for (var r, u = t; (u = u.__); )
+				if ((r = u.__c) && r.__c)
+					return (
+						null == t.__e && ((t.__e = e.__e), (t.__k = e.__k)), r.__c(n, t)
+					);
+		h(n, t, e);
+	}),
+		((p.prototype = new e.Component()).__c = function (n, t) {
+			var e = t.__c,
+				r = this;
+			null == r.t && (r.t = []), r.t.push(e);
+			var u = d(r.__v),
+				o = !1,
+				i = function () {
+					o || ((o = !0), (e.componentWillUnmount = e.__c), u ? u(f) : f());
+				};
+			(e.__c = e.componentWillUnmount),
+				(e.componentWillUnmount = function () {
+					i(), e.__c && e.__c();
+				});
+			var f = function () {
+					if (!--r.__u) {
+						if (r.state.__e) {
+							var n = r.state.__e;
+							r.__v.__k[0] = (function n(t, e, r) {
+								return (
+									t &&
+										((t.__v = null),
+										(t.__k =
+											t.__k &&
+											t.__k.map(function (t) {
+												return n(t, e, r);
+											})),
+										t.__c &&
+											t.__c.__P === e &&
+											(t.__e && r.insertBefore(t.__e, t.__d),
+											(t.__c.__e = !0),
+											(t.__c.__P = r))),
+									t
+								);
+							})(n, n.__c.__P, n.__c.__O);
+						}
+						var t;
+						for (r.setState({ __e: (r.__b = null) }); (t = r.t.pop()); )
+							t.forceUpdate();
+					}
+				},
+				c = !0 === t.__h;
+			r.__u++ || c || r.setState({ __e: (r.__b = r.__v.__k[0]) }), n.then(i, i);
+		}),
+		(p.prototype.componentWillUnmount = function () {
+			this.t = [];
+		}),
+		(p.prototype.render = function (n, t) {
+			if (this.__b) {
+				if (this.__v.__k) {
+					var u = document.createElement("div"),
+						o = this.__v.__k[0].__c;
+					this.__v.__k[0] = (function n(t, e, u) {
+						return (
+							t &&
+								(t.__c &&
+									t.__c.__H &&
+									(t.__c.__H.__.forEach(function (n) {
+										"function" == typeof n.__c && n.__c();
+									}),
+									(t.__c.__H = null)),
+								null != (t = r({}, t)).__c &&
+									(t.__c.__P === u && (t.__c.__P = e), (t.__c = null)),
+								(t.__k =
+									t.__k &&
+									t.__k.map(function (t) {
+										return n(t, e, u);
+									}))),
+							t
+						);
+					})(this.__b, u, (o.__O = o.__P));
+				}
+				this.__b = null;
+			}
+			var i = t.__e && e.createElement(e.Fragment, null, n.fallback);
+			return (
+				i && (i.__h = null),
+				[e.createElement(e.Fragment, null, t.__e ? null : n.children), i]
+			);
+		});
+	var y = function (n, t, e) {
+		if (
+			(++e[1] === e[0] && n.o.delete(t),
+			n.props.revealOrder && ("t" !== n.props.revealOrder[0] || !n.o.size))
+		)
+			for (e = n.u; e; ) {
+				for (; e.length > 3; ) e.pop()();
+				if (e[1] < e[0]) break;
+				n.u = e = e[2];
+			}
+	};
+	function b(n) {
+		return (
+			(this.getChildContext = function () {
+				return n.context;
+			}),
+			n.children
+		);
+	}
+	function _(n) {
+		var t = this,
+			r = n.i;
+		(t.componentWillUnmount = function () {
+			e.render(null, t.l), (t.l = null), (t.i = null);
+		}),
+			t.i && t.i !== r && t.componentWillUnmount(),
+			n.__v
+				? (t.l ||
+						((t.i = r),
+						(t.l = {
+							nodeType: 1,
+							parentNode: r,
+							childNodes: [],
+							appendChild: function (n) {
+								this.childNodes.push(n), t.i.appendChild(n);
+							},
+							insertBefore: function (n, e) {
+								this.childNodes.push(n), t.i.appendChild(n);
+							},
+							removeChild: function (n) {
+								this.childNodes.splice(this.childNodes.indexOf(n) >>> 1, 1),
+									t.i.removeChild(n);
+							},
+						})),
+				  e.render(e.createElement(b, { context: t.context }, n.__v), t.l))
+				: t.l && t.componentWillUnmount();
+	}
+	function S(n, t) {
+		return e.createElement(_, { __v: n, i: t });
+	}
+	((m.prototype = new e.Component()).__e = function (n) {
+		var t = this,
+			e = d(t.__v),
+			r = t.o.get(n);
+		return (
+			r[0]++,
+			function (u) {
+				var o = function () {
+					t.props.revealOrder ? (r.push(u), y(t, n, r)) : u();
+				};
+				e ? e(o) : o();
+			}
+		);
+	}),
+		(m.prototype.render = function (n) {
+			(this.u = null), (this.o = new Map());
+			var t = e.toChildArray(n.children);
+			n.revealOrder && "b" === n.revealOrder[0] && t.reverse();
+			for (var r = t.length; r--; ) this.o.set(t[r], (this.u = [1, 0, this.u]));
+			return n.children;
+		}),
+		(m.prototype.componentDidUpdate = m.prototype.componentDidMount = function () {
+			var n = this;
+			this.o.forEach(function (t, e) {
+				y(n, e, t);
+			});
+		});
+	var w =
+			("undefined" != typeof Symbol &&
+				Symbol.for &&
+				Symbol.for("react.element")) ||
+			60103,
+		C = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/,
+		g = function (n) {
+			return ("undefined" != typeof Symbol && "symbol" == typeof Symbol()
+				? /fil|che|rad/i
+				: /fil|che|ra/i
+			).test(n);
+		};
+	function E(n, t, r) {
+		return (
+			null == t.__k && (t.textContent = ""),
+			e.render(n, t),
+			"function" == typeof r && r(),
+			n ? n.__c : null
+		);
+	}
+	function R(n, t, r) {
+		return e.hydrate(n, t), "function" == typeof r && r(), n ? n.__c : null;
+	}
+	(e.Component.prototype.isReactComponent = {}),
+		[
+			"componentWillMount",
+			"componentWillReceiveProps",
+			"componentWillUpdate",
+		].forEach(function (n) {
+			Object.defineProperty(e.Component.prototype, n, {
+				configurable: !0,
+				get: function () {
+					return this["UNSAFE_" + n];
+				},
+				set: function (t) {
+					Object.defineProperty(this, n, {
+						configurable: !0,
+						writable: !0,
+						value: t,
+					});
+				},
+			});
+		});
+	var x = e.options.event;
+	function N() {}
+	function k() {
+		return this.cancelBubble;
+	}
+	function O() {
+		return this.defaultPrevented;
+	}
+	e.options.event = function (n) {
+		return (
+			x && (n = x(n)),
+			(n.persist = N),
+			(n.isPropagationStopped = k),
+			(n.isDefaultPrevented = O),
+			(n.nativeEvent = n)
+		);
+	};
+	var A,
+		j = {
+			configurable: !0,
+			get: function () {
+				return this.class;
+			},
+		},
+		L = e.options.vnode;
+	e.options.vnode = function (n) {
+		var t = n.type,
+			r = n.props,
+			u = r;
+		if ("string" == typeof t) {
+			for (var o in ((u = {}), r)) {
+				var i = r[o];
+				"defaultValue" === o && "value" in r && null == r.value
+					? (o = "value")
+					: "download" === o && !0 === i
+					? (i = "")
+					: /ondoubleclick/i.test(o)
+					? (o = "ondblclick")
+					: /^onchange(textarea|input)/i.test(o + t) && !g(r.type)
+					? (o = "oninput")
+					: /^on(Ani|Tra|Tou|BeforeInp)/.test(o)
+					? (o = o.toLowerCase())
+					: C.test(o)
+					? (o = o.replace(/[A-Z0-9]/, "-$&").toLowerCase())
+					: null === i && (i = void 0),
+					(u[o] = i);
+			}
+			"select" == t &&
+				u.multiple &&
+				Array.isArray(u.value) &&
+				(u.value = e.toChildArray(r.children).forEach(function (n) {
+					n.props.selected = -1 != u.value.indexOf(n.props.value);
+				})),
+				"select" == t &&
+					null != u.defaultValue &&
+					(u.value = e.toChildArray(r.children).forEach(function (n) {
+						n.props.selected = u.multiple
+							? -1 != u.defaultValue.indexOf(n.props.value)
+							: u.defaultValue == n.props.value;
+					})),
+				(n.props = u);
+		}
+		t &&
+			r.class != r.className &&
+			((j.enumerable = "className" in r),
+			null != r.className && (u.class = r.className),
+			Object.defineProperty(u, "className", j)),
+			(n.$$typeof = w),
+			L && L(n);
+	};
+	var U = e.options.__r;
+	e.options.__r = function (n) {
+		U && U(n), (A = n.__c);
+	};
+	var D = {
+			ReactCurrentDispatcher: {
+				current: {
+					readContext: function (n) {
+						return A.__n[n.__c].props.value;
+					},
+				},
+			},
+		},
+		M =
+			"object" == typeof performance && "function" == typeof performance.now
+				? performance.now.bind(performance)
+				: function () {
+						return Date.now();
+				  };
+	function T(n) {
+		return e.createElement.bind(null, n);
+	}
+	function F(n) {
+		return !!n && n.$$typeof === w;
+	}
+	function I(n) {
+		return F(n) ? e.cloneElement.apply(null, arguments) : n;
+	}
+	function W(n) {
+		return !!n.__k && (e.render(null, n), !0);
+	}
+	function P(n) {
+		return (n && (n.base || (1 === n.nodeType && n))) || null;
+	}
+	var z = function (n, t) {
+			return n(t);
+		},
+		B = e.Fragment,
+		V = {
+			useState: t.useState,
+			useReducer: t.useReducer,
+			useEffect: t.useEffect,
+			useLayoutEffect: t.useLayoutEffect,
+			useRef: t.useRef,
+			useImperativeHandle: t.useImperativeHandle,
+			useMemo: t.useMemo,
+			useCallback: t.useCallback,
+			useContext: t.useContext,
+			useDebugValue: t.useDebugValue,
+			version: "16.8.0",
+			Children: s,
+			render: E,
+			hydrate: R,
+			unmountComponentAtNode: W,
+			createPortal: S,
+			createElement: e.createElement,
+			createContext: e.createContext,
+			createFactory: T,
+			cloneElement: I,
+			createRef: e.createRef,
+			Fragment: e.Fragment,
+			isValidElement: F,
+			findDOMNode: P,
+			Component: e.Component,
+			PureComponent: o,
+			memo: i,
+			forwardRef: l,
+			unstable_batchedUpdates: z,
+			StrictMode: B,
+			Suspense: p,
+			SuspenseList: m,
+			lazy: v,
+			__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: D,
+		};
+	Object.keys(t).forEach(function (e) {
+		n[e] = t[e];
+	}),
+		(n.createElement = e.createElement),
+		(n.createContext = e.createContext),
+		(n.createRef = e.createRef),
+		(n.Fragment = e.Fragment),
+		(n.Component = e.Component),
+		(n.version = "16.8.0"),
+		(n.Children = s),
+		(n.render = E),
+		(n.hydrate = R),
+		(n.unmountComponentAtNode = W),
+		(n.createPortal = S),
+		(n.createFactory = T),
+		(n.cloneElement = I),
+		(n.isValidElement = F),
+		(n.findDOMNode = P),
+		(n.PureComponent = o),
+		(n.memo = i),
+		(n.forwardRef = l),
+		(n.unstable_batchedUpdates = z),
+		(n.StrictMode = B),
+		(n.Suspense = p),
+		(n.SuspenseList = m),
+		(n.lazy = v),
+		(n.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = D),
+		(n.default = V),
+		(n.unstable_ImmediatePriority = 1),
+		(n.unstable_UserBlockingPriority = 2),
+		(n.unstable_NormalPriority = 3),
+		(n.unstable_LowPriority = 4),
+		(n.unstable_IdlePriority = 5),
+		(n.unstable_runWithPriority = function (n, t) {
+			return t();
+		}),
+		(n.unstable_now = M);
+});
+//# sourceMappingURL=compat.umd.js.map

--- a/test-e2e/fixtures/vendor/preact/use-debug-name/preactDebug.js
+++ b/test-e2e/fixtures/vendor/preact/use-debug-name/preactDebug.js
@@ -1,0 +1,429 @@
+!(function (n, e) {
+	"object" == typeof exports && "undefined" != typeof module
+		? e(exports, require("preact"), require("preact/devtools"))
+		: "function" == typeof define && define.amd
+		? define(["exports", "preact", "preact/devtools"], e)
+		: e((n.preactDebug = {}), n.preact);
+})(this, function (n, e) {
+	var t = {};
+	function o(n) {
+		return n.type === e.Fragment
+			? "Fragment"
+			: "function" == typeof n.type
+			? n.type.displayName || n.type.name
+			: "string" == typeof n.type
+			? n.type
+			: "#text";
+	}
+	var r = [],
+		i = [];
+	function a() {
+		return r.length > 0 ? r[r.length - 1] : null;
+	}
+	var s = !1;
+	function c(n) {
+		return "function" == typeof n.type && n.type != e.Fragment;
+	}
+	function u(n) {
+		for (var e = [n], t = n; null != t.__o; ) e.push(t.__o), (t = t.__o);
+		return e.reduce(function (n, e) {
+			n += "  in " + o(e);
+			var t = e.__source;
+			return (
+				t
+					? (n += " (at " + t.fileName + ":" + t.lineNumber + ")")
+					: s ||
+					  ((s = !0),
+					  console.warn(
+							"Add @babel/plugin-transform-react-jsx-source to get a more detailed component stack. Note that you should not add it to production builds of your App for bundle size reasons.",
+					  )),
+				n + "\n"
+			);
+		}, "");
+	}
+	var l = "function" == typeof WeakMap,
+		f = e.Component.prototype.setState;
+	e.Component.prototype.setState = function (n, e) {
+		return (
+			null == this.__v
+				? null == this.state &&
+				  console.warn(
+						'Calling "this.setState" inside the constructor of a component is a no-op and might be a bug in your application. Instead, set "this.state = {}" directly.\n\n' +
+							u(a()),
+				  )
+				: null == this.__P &&
+				  console.warn(
+						'Can\'t call "this.setState" on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.\n\n' +
+							u(this.__v),
+				  ),
+			f.call(this, n, e)
+		);
+	};
+	var p = e.Component.prototype.forceUpdate;
+	function d(n) {
+		var e = n.props,
+			t = o(n),
+			r = "";
+		for (var i in e)
+			if (e.hasOwnProperty(i) && "children" !== i) {
+				var a = e[i];
+				"function" == typeof a &&
+					(a = "function " + (a.displayName || a.name) + "() {}"),
+					(a =
+						Object(a) !== a || a.toString
+							? a + ""
+							: Object.prototype.toString.call(a)),
+					(r += " " + i + "=" + JSON.stringify(a));
+			}
+		var s = e.children;
+		return "<" + t + r + (s && s.length ? ">..</" + t + ">" : " />");
+	}
+	(e.Component.prototype.forceUpdate = function (n) {
+		return (
+			null == this.__v
+				? console.warn(
+						'Calling "this.forceUpdate" inside the constructor of a component is a no-op and might be a bug in your application.\n\n' +
+							u(a()),
+				  )
+				: null == this.__P &&
+				  console.warn(
+						'Can\'t call "this.forceUpdate" on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.\n\n' +
+							u(this.__v),
+				  ),
+			p.call(this, n)
+		);
+	}),
+		(function () {
+			!(function () {
+				var n = e.options.__b,
+					t = e.options.diffed,
+					o = e.options.__,
+					a = e.options.vnode,
+					s = e.options.__r;
+				(e.options.diffed = function (n) {
+					c(n) && i.pop(), r.pop(), t && t(n);
+				}),
+					(e.options.__b = function (e) {
+						c(e) && r.push(e), n && n(e);
+					}),
+					(e.options.__ = function (n, e) {
+						(i = []), o && o(n, e);
+					}),
+					(e.options.vnode = function (n) {
+						(n.__o = i.length > 0 ? i[i.length - 1] : null), a && a(n);
+					}),
+					(e.options.__r = function (n) {
+						c(n) && i.push(n), s && s(n);
+					});
+			})();
+			var n = !1,
+				a = e.options.__b,
+				s = e.options.diffed,
+				f = e.options.vnode,
+				p = e.options.__e,
+				h = e.options.__,
+				y = e.options.__h,
+				v = l
+					? {
+							useEffect: new WeakMap(),
+							useLayoutEffect: new WeakMap(),
+							lazyPropTypes: new WeakMap(),
+					  }
+					: null,
+				m = [];
+			(e.options.__e = function (n, e, t) {
+				if (e && e.__c && "function" == typeof n.then) {
+					var r = n;
+					n = new Error(
+						"Missing Suspense. The throwing component was: " + o(e),
+					);
+					for (var i = e; i; i = i.__)
+						if (i.__c && i.__c.__c) {
+							n = r;
+							break;
+						}
+					if (n instanceof Error) throw n;
+				}
+				try {
+					p(n, e, t),
+						"function" != typeof n.then &&
+							setTimeout(function () {
+								throw n;
+							});
+				} catch (n) {
+					throw n;
+				}
+			}),
+				(e.options.__ = function (n, e) {
+					if (!e)
+						throw new Error(
+							"Undefined parent passed to render(), this is the second argument.\nCheck if the element is available in the DOM/has the correct id.",
+						);
+					var t;
+					switch (e.nodeType) {
+						case 1:
+						case 11:
+						case 9:
+							t = !0;
+							break;
+						default:
+							t = !1;
+					}
+					if (!t) {
+						var r = o(n);
+						throw new Error(
+							"Expected a valid HTML node as a second argument to render.\tReceived " +
+								e +
+								" instead: render(<" +
+								r +
+								" />, " +
+								e +
+								");",
+						);
+					}
+					h && h(n, e);
+				}),
+				(e.options.__b = function (e) {
+					var r = e.type,
+						i = (function n(e) {
+							return e ? ("function" == typeof e.type ? n(e.__) : e) : {};
+						})(e.__);
+					if (((n = !0), void 0 === r))
+						throw new Error(
+							"Undefined component passed to createElement()\n\nYou likely forgot to export your component or might have mixed up default and named imports" +
+								d(e) +
+								"\n\n" +
+								u(e),
+						);
+					if (null != r && "object" == typeof r) {
+						if (void 0 !== r.__k && void 0 !== r.__e)
+							throw new Error(
+								"Invalid type passed to createElement(): " +
+									r +
+									"\n\nDid you accidentally pass a JSX literal as JSX twice?\n\n  let My" +
+									o(e) +
+									" = " +
+									d(r) +
+									";\n  let vnode = <My" +
+									o(e) +
+									" />;\n\nThis usually happens when you export a JSX literal and not the component.\n\n" +
+									u(e),
+							);
+						throw new Error(
+							"Invalid type passed to createElement(): " +
+								(Array.isArray(r) ? "array" : r),
+						);
+					}
+					if (
+						(("thead" !== r && "tfoot" !== r && "tbody" !== r) ||
+						"table" === i.type
+							? "tr" === r &&
+							  "thead" !== i.type &&
+							  "tfoot" !== i.type &&
+							  "tbody" !== i.type &&
+							  "table" !== i.type
+								? console.error(
+										"Improper nesting of table. Your <tr> should have a <thead/tbody/tfoot/table> parent." +
+											d(e) +
+											"\n\n" +
+											u(e),
+								  )
+								: "td" === r && "tr" !== i.type
+								? console.error(
+										"Improper nesting of table. Your <td> should have a <tr> parent." +
+											d(e) +
+											"\n\n" +
+											u(e),
+								  )
+								: "th" === r &&
+								  "tr" !== i.type &&
+								  console.error(
+										"Improper nesting of table. Your <th> should have a <tr>." +
+											d(e) +
+											"\n\n" +
+											u(e),
+								  )
+							: console.error(
+									"Improper nesting of table. Your <thead/tbody/tfoot> should have a <table> parent." +
+										d(e) +
+										"\n\n" +
+										u(e),
+							  ),
+						void 0 !== e.ref &&
+							"function" != typeof e.ref &&
+							"object" != typeof e.ref &&
+							!("$$typeof" in e))
+					)
+						throw new Error(
+							'Component\'s "ref" property should be a function, or an object created by createRef(), but got [' +
+								typeof e.ref +
+								"] instead\n" +
+								d(e) +
+								"\n\n" +
+								u(e),
+						);
+					if ("string" == typeof e.type)
+						for (var s in e.props)
+							if (
+								"o" === s[0] &&
+								"n" === s[1] &&
+								"function" != typeof e.props[s] &&
+								null != e.props[s]
+							)
+								throw new Error(
+									"Component's \"" +
+										s +
+										'" property should be a function, but got [' +
+										typeof e.props[s] +
+										"] instead\n" +
+										d(e) +
+										"\n\n" +
+										u(e),
+								);
+					if ("function" == typeof e.type && e.type.propTypes) {
+						if (
+							"Lazy" === e.type.displayName &&
+							v &&
+							!v.lazyPropTypes.has(e.type)
+						) {
+							var c =
+								"PropTypes are not supported on lazy(). Use propTypes on the wrapped component itself. ";
+							try {
+								var l = e.type();
+								v.lazyPropTypes.set(e.type, !0),
+									console.warn(c + "Component wrapped in lazy() is " + o(l));
+							} catch (n) {
+								console.warn(
+									c +
+										"We will log the wrapped component's name once it is loaded.",
+								);
+							}
+						}
+						var f = e.props;
+						e.type.__f &&
+							delete (f = (function (n, e) {
+								for (var t in e) n[t] = e[t];
+								return n;
+							})({}, f)).ref,
+							(function (n, e, o, r, i) {
+								Object.keys(n).forEach(function (o) {
+									var a;
+									try {
+										a = n[o](
+											e,
+											o,
+											r,
+											"prop",
+											null,
+											"SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
+										);
+									} catch (n) {
+										a = n;
+									}
+									!a ||
+										a.message in t ||
+										((t[a.message] = !0),
+										console.error(
+											"Failed prop type: " +
+												a.message +
+												((i && "\n" + i()) || ""),
+										));
+								});
+							})(e.type.propTypes, f, 0, o(e), function () {
+								return u(e);
+							});
+					}
+					a && a(e);
+				}),
+				(e.options.__h = function (e, t, o) {
+					if (!e || !n)
+						throw new Error("Hook can only be invoked from render methods.");
+					y && y(e, t, o);
+				});
+			var b = function (n, e) {
+					return {
+						get: function () {
+							var t = "get" + n + e;
+							m &&
+								m.indexOf(t) < 0 &&
+								(m.push(t),
+								console.warn("getting vnode." + n + " is deprecated, " + e));
+						},
+						set: function () {
+							var t = "set" + n + e;
+							m &&
+								m.indexOf(t) < 0 &&
+								(m.push(t),
+								console.warn("setting vnode." + n + " is not allowed, " + e));
+						},
+					};
+				},
+				w = {
+					nodeName: b("nodeName", "use vnode.type"),
+					attributes: b("attributes", "use vnode.props"),
+					children: b("children", "use vnode.props.children"),
+				},
+				g = Object.create({}, w);
+			(e.options.vnode = function (n) {
+				var e = n.props;
+				if (
+					null !== n.type &&
+					null != e &&
+					("__source" in e || "__self" in e)
+				) {
+					var t = (n.props = {});
+					for (var o in e) {
+						var r = e[o];
+						"__source" === o
+							? (n.__source = r)
+							: "__self" === o
+							? (n.__self = r)
+							: (t[o] = r);
+					}
+				}
+				(n.__proto__ = g), f && f(n);
+			}),
+				(e.options.diffed = function (e) {
+					if (
+						(e.__k &&
+							e.__k.forEach(function (n) {
+								if (n && void 0 === n.type) {
+									delete n.__, delete n.__b;
+									var t = Object.keys(n).join(",");
+									throw new Error(
+										"Objects are not valid as a child. Encountered an object with the keys {" +
+											t +
+											"}.\n\n" +
+											u(e),
+									);
+								}
+							}),
+						(n = !1),
+						s && s(e),
+						null != e.__k)
+					)
+						for (var t = [], o = 0; o < e.__k.length; o++) {
+							var r = e.__k[o];
+							if (r && null != r.key) {
+								var i = r.key;
+								if (-1 !== t.indexOf(i)) {
+									console.error(
+										'Following component has two or more children with the same key attribute: "' +
+											i +
+											'". This may cause glitches and misbehavior in rendering process. Component: \n\n' +
+											d(e) +
+											"\n\n" +
+											u(e),
+									);
+									break;
+								}
+								t.push(i);
+							}
+						}
+				});
+		})(),
+		(n.resetPropWarnings = function () {
+			t = {};
+		});
+});
+//# sourceMappingURL=debug.umd.js.map

--- a/test-e2e/fixtures/vendor/preact/use-debug-name/preactDevtools.js
+++ b/test-e2e/fixtures/vendor/preact/use-debug-name/preactDevtools.js
@@ -1,0 +1,12 @@
+function attachToDevtools(preact) {
+	window.__PREACT_DEVTOOLS__.attachPreact("10.5.10", preact.options, {
+		Fragment: preact.Fragment,
+		Component: preact.Component,
+	});
+}
+
+preactDevtools = {
+	addHookName: function (e, o) {
+		return preact.options.__a && preact.options.__a(o), e;
+	},
+};

--- a/test-e2e/fixtures/vendor/preact/use-debug-name/preactHooks.js
+++ b/test-e2e/fixtures/vendor/preact/use-debug-name/preactHooks.js
@@ -1,0 +1,207 @@
+!(function (n, t) {
+	"object" == typeof exports && "undefined" != typeof module
+		? t(exports, require("preact"))
+		: "function" == typeof define && define.amd
+		? define(["exports", "preact"], t)
+		: t((n.preactHooks = {}), n.preact);
+})(this, function (n, t) {
+	var u,
+		o,
+		i,
+		r = 0,
+		c = [],
+		f = t.options.__b,
+		e = t.options.__r,
+		a = t.options.diffed,
+		v = t.options.__c,
+		p = t.options.unmount;
+	function m(n, u) {
+		t.options.__h && t.options.__h(o, n, r || u), (r = 0);
+		var i = o.__H || (o.__H = { __: [], __h: [] });
+		return n >= i.__.length && i.__.push({}), i.__[n];
+	}
+	function y(n) {
+		return (r = 1), d(F, n);
+	}
+	function d(n, t, i) {
+		var r = m(u++, 2);
+		return (
+			(r.t = n),
+			r.__c ||
+				((r.__ = [
+					(i = i ? i(t) : F(void 0, t)),
+					function (n) {
+						var t = r.t(r.__[0], n);
+						r.__[0] !== t &&
+							t !== r.__[2] &&
+							((r.__ = [t, r.__[1]]),
+							r.__c.setState({}, function () {
+								r.__[2] = t;
+							}));
+					},
+					i,
+				]),
+				(r.__c = o)),
+			r.__
+		);
+	}
+	function l(n, i) {
+		var r = m(u++, 4);
+		!t.options.__s && A(r.__H, i) && ((r.__ = n), (r.__H = i), o.__h.push(r));
+	}
+	function s(n, t) {
+		var o = m(u++, 7);
+		return A(o.__H, t) && ((o.__ = n()), (o.__H = t), (o.__h = n)), o.__;
+	}
+	function h() {
+		c.forEach(function (n) {
+			if (n.__P)
+				try {
+					n.__H.__h.forEach(q), n.__H.__h.forEach(x), (n.__H.__h = []);
+				} catch (u) {
+					(n.__H.__h = []), t.options.__e(u, n.__v);
+				}
+		}),
+			(c = []);
+	}
+	(t.options.__b = function (n) {
+		(o = null), f && f(n);
+	}),
+		(t.options.__r = function (n) {
+			e && e(n), (u = 0);
+			var t = (o = n.__c).__H;
+			t && (t.__h.forEach(q), t.__h.forEach(x), (t.__h = []));
+		}),
+		(t.options.diffed = function (n) {
+			a && a(n);
+			var u = n.__c;
+			u &&
+				u.__H &&
+				u.__H.__h.length &&
+				((1 !== c.push(u) && i === t.options.requestAnimationFrame) ||
+					(
+						(i = t.options.requestAnimationFrame) ||
+						function (n) {
+							var t,
+								u = function () {
+									clearTimeout(o), _ && cancelAnimationFrame(t), setTimeout(n);
+								},
+								o = setTimeout(u, 100);
+							_ && (t = requestAnimationFrame(u));
+						}
+					)(h)),
+				(o = void 0);
+		}),
+		(t.options.__c = function (n, u) {
+			u.some(function (n) {
+				try {
+					n.__h.forEach(q),
+						(n.__h = n.__h.filter(function (n) {
+							return !n.__ || x(n);
+						}));
+				} catch (o) {
+					u.some(function (n) {
+						n.__h && (n.__h = []);
+					}),
+						(u = []),
+						t.options.__e(o, n.__v);
+				}
+			}),
+				v && v(n, u);
+		}),
+		(t.options.unmount = function (n) {
+			p && p(n);
+			var u = n.__c;
+			if (u && u.__H)
+				try {
+					u.__H.__.forEach(q);
+				} catch (n) {
+					t.options.__e(n, u.__v);
+				}
+		});
+	var _ = "function" == typeof requestAnimationFrame;
+	function q(n) {
+		var t = o;
+		"function" == typeof n.__c && n.__c(), (o = t);
+	}
+	function x(n) {
+		var t = o;
+		(n.__c = n.__()), (o = t);
+	}
+	function A(n, t) {
+		return (
+			!n ||
+			n.length !== t.length ||
+			t.some(function (t, u) {
+				return t !== n[u];
+			})
+		);
+	}
+	function F(n, t) {
+		return "function" == typeof t ? t(n) : t;
+	}
+	(n.useState = y),
+		(n.useReducer = d),
+		(n.useEffect = function (n, i) {
+			var r = m(u++, 3);
+			!t.options.__s &&
+				A(r.__H, i) &&
+				((r.__ = n), (r.__H = i), o.__H.__h.push(r));
+		}),
+		(n.useLayoutEffect = l),
+		(n.useRef = function (n) {
+			return (
+				(r = 5),
+				s(function () {
+					return { current: n };
+				}, [])
+			);
+		}),
+		(n.useImperativeHandle = function (n, t, u) {
+			(r = 6),
+				l(
+					function () {
+						"function" == typeof n ? n(t()) : n && (n.current = t());
+					},
+					null == u ? u : u.concat(n),
+				);
+		}),
+		(n.useMemo = s),
+		(n.useCallback = function (n, t) {
+			return (
+				(r = 8),
+				s(function () {
+					return n;
+				}, t)
+			);
+		}),
+		(n.useContext = function (n) {
+			var t = o.context[n.__c],
+				i = m(u++, 9);
+			return (
+				(i.__c = n),
+				t ? (null == i.__ && ((i.__ = !0), t.sub(o)), t.props.value) : n.__
+			);
+		}),
+		(n.useDebugValue = function (n, u) {
+			t.options.useDebugValue && t.options.useDebugValue(u ? u(n) : n);
+		}),
+		(n.useErrorBoundary = function (n) {
+			var t = m(u++, 10),
+				i = y();
+			return (
+				(t.__ = n),
+				o.componentDidCatch ||
+					(o.componentDidCatch = function (n) {
+						t.__ && t.__(n), i[1](n);
+					}),
+				[
+					i[0],
+					function () {
+						i[1](void 0);
+					},
+				]
+			);
+		});
+});
+//# sourceMappingURL=hooks.umd.js.map

--- a/test-e2e/test-utils.ts
+++ b/test-e2e/test-utils.ts
@@ -321,3 +321,25 @@ export async function installMouseHelper(page: Page) {
 		document.addEventListener("mouseup", handleEvent, true);
 	});
 }
+
+export async function getHooks(page: Page): Promise<Array<[string, string]>> {
+	return await page.evaluate(() => {
+		const rows = Array.from(
+			document.querySelectorAll('[data-testid="props-row"]'),
+		);
+
+		return rows.map(item => {
+			const name = item.querySelector('[data-testid="prop-name"]')!.textContent;
+			let value = item.querySelector('[data-testid="prop-value"]')!.textContent;
+
+			// Check if we're dealing with an input
+			if (!value) {
+				value =
+					"" +
+					(item.querySelector('[data-testid="prop-value"] input') as any).value;
+			}
+
+			return [name, value] as [string, string];
+		}, []);
+	});
+}

--- a/test-e2e/tests/hooks/hook-name.test.ts
+++ b/test-e2e/tests/hooks/hook-name.test.ts
@@ -1,0 +1,54 @@
+import { newTestPage, getHooks } from "../../test-utils";
+import { expect } from "chai";
+import { clickNestedText } from "pentf/browser_utils";
+
+export const description = "Show custom hook name";
+
+export async function run(config: any) {
+	const { devtools } = await newTestPage(config, "hooks-name", {
+		preact: "use-debug-name",
+	});
+
+	const hooksPanel = '[data-testid="props-row"]';
+
+	// Counter
+	await clickNestedText(devtools, /Counter$/, {
+		retryUntil: async () => {
+			return !!(await devtools.$('[data-testid="Hooks"]'));
+		},
+	});
+	await devtools.waitForSelector(hooksPanel);
+
+	expect(await getHooks(devtools)).to.deep.equal([["customState", "0"]]);
+
+	// Callback (Mixed)
+	await clickNestedText(devtools, /CounterCallback$/);
+	await devtools.waitForSelector(hooksPanel);
+	expect(await getHooks(devtools)).to.deep.equal([
+		["counterState", "0"],
+		["useCallback", "ƒ ()"],
+	]);
+
+	// Reducer
+	await clickNestedText(devtools, /ReducerComponent$/);
+	await devtools.waitForSelector(hooksPanel);
+	expect(await getHooks(devtools)).to.deep.equal([["customReducer", '"foo"']]);
+
+	// Ref
+	await clickNestedText(devtools, /RefComponent$/);
+	await devtools.waitForSelector(hooksPanel);
+	expect(await getHooks(devtools)).to.deep.equal([["customRef", "0"]]);
+
+	// Do nothing for invalid callsites
+	await clickNestedText(devtools, /CallbackOnly$/);
+	await devtools.waitForSelector(hooksPanel);
+	expect(await getHooks(devtools)).to.deep.equal([["useCallback", "ƒ ()"]]);
+
+	await clickNestedText(devtools, /LayoutEffect$/);
+	await devtools.waitForSelector(hooksPanel);
+	expect(await getHooks(devtools)).to.deep.equal([["useLayoutEffect", "ƒ ()"]]);
+
+	await clickNestedText(devtools, /^Effect$/);
+	await devtools.waitForSelector(hooksPanel);
+	expect(await getHooks(devtools)).to.deep.equal([["useEffect", "ƒ ()"]]);
+}


### PR DESCRIPTION
This PR adds support for customizing native hook names via a `useDebugName` hook.

<img width="321" alt="Screenshot 2021-01-21 at 22 36 56" src="https://user-images.githubusercontent.com/1062408/105415549-2c3cb780-5c39-11eb-8f38-a147d98fb589.png">


Fixes #280 

Marked as draft until https://github.com/preactjs/preact/pull/2952 is resolved.