### PR TITLE
Fix empty panel in Firefox

### DIFF
--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -97,7 +97,7 @@ export function createHook(port: PortPageHook): DevtoolsHook {
 		status = "pending";
 		send("init", null);
 
-		listen("initialized", () => {
+		listen("init", () => {
 			status = "connected";
 			multi.flushInitial();
 		});


### PR DESCRIPTION
This was a tricky one! Basically Firefox and Chrome fire the `onNavigated` event at different times. Chrome fires it as soon as the user navigates away and before the page starts to load. This in my opinion is the expected result.

Firefox on the other hand fires that event seemingly at random _after_ all scripts are loaded. This leads to a weird situation where the user navigates, we setup a connection and push events to the extension and only after that Firefox notifies us that a navigation took place. This is way too late as events have already been pushed at this point.