### PR TITLE
Update useContext() hook state property for preactjs/preact#3165

### DIFF
--- a/src/adapter/10/vnode.ts
+++ b/src/adapter/10/vnode.ts
@@ -102,7 +102,7 @@ export function getHookState(
 	if (list && list[index]) {
 		// useContext
 		if (type === HookType.useContext) {
-			const context = list[index]._context || list[index].__c;
+			const context = list[index]._context || list[index].__c || list[index].c;
 			const provider = c.context[context._id] || c.context[context.__c];
 			return provider
 				? provider.props.value


### PR DESCRIPTION
This updates the `useContext()` hook state property (`_context`) to reflect it being renamed to `c` in preactjs/preact#3165.