### PR TITLE
Handle plain objects that look like collections

### DIFF
--- a/src/view/components/sidebar/inspect/parseProps.test.ts
+++ b/src/view/components/sidebar/inspect/parseProps.test.ts
@@ -240,6 +240,56 @@ describe("parseProps", () => {
 		]);
 	});
 
+	it("should flatten plain objects that are read as 'maybeCollections'", () => {
+		const tree = parseProps({ foo: 123, bar: "abc", name: "bob" }, "", 2);
+		expect(serialize(tree)).to.deep.equal([
+			{
+				editable: false,
+				depth: 0,
+				id: "",
+				name: "",
+				type: "object",
+				value: {
+					foo: 123,
+					bar: "abc",
+					name: "bob",
+				},
+				children: [".foo", ".bar", ".name"],
+				meta: null,
+			},
+			{
+				editable: true,
+				depth: 1,
+				id: ".foo",
+				name: "foo",
+				type: "number",
+				value: 123,
+				children: [],
+				meta: null,
+			},
+			{
+				editable: true,
+				depth: 1,
+				id: ".bar",
+				name: "bar",
+				type: "string",
+				value: "abc",
+				children: [],
+				meta: null,
+			},
+			{
+				editable: true,
+				depth: 1,
+				id: ".name",
+				name: "name",
+				type: "string",
+				value: "bob",
+				children: [],
+				meta: null,
+			},
+		]);
+	});
+
 	it("should limit depth", () => {
 		const tree = parseProps({ foo: { bar: { boof: "abc" } } }, "foo", 2);
 		expect(serialize(tree)).to.deep.equal([

--- a/src/view/components/sidebar/inspect/parseProps.ts
+++ b/src/view/components/sidebar/inspect/parseProps.ts
@@ -116,47 +116,51 @@ export function parseProps(
 			} else if (
 				// Same for Set + Map
 				maybeCollection &&
-				typeof data.name === "string"
+				typeof data.name === "string" &&
+				data.type === "set"
 			) {
-				if (data.type === "set") {
-					const children: any[] = [];
-					const node: PropData = {
-						depth,
-						name,
-						id: path,
-						type: "set",
-						editable: false,
-						value: data,
-						children,
-						meta: null,
-					};
+				const children: any[] = [];
+				const node: PropData = {
+					depth,
+					name,
+					id: path,
+					type: "set",
+					editable: false,
+					value: data,
+					children,
+					meta: null,
+				};
 
-					(data.entries as any[]).forEach((item, i) => {
-						const childPath = `${path}.${i}`;
-						children.push(childPath);
-						parseProps(item, childPath, limit, depth + 1, "" + i, out);
-					});
-					out.set(path, node);
-				} else if (data.type === "map") {
-					const children: any[] = [];
-					const node: PropData = {
-						depth,
-						name,
-						id: path,
-						type: "map",
-						editable: false,
-						value: data,
-						children,
-						meta: null,
-					};
+				(data.entries as any[]).forEach((item, i) => {
+					const childPath = `${path}.${i}`;
+					children.push(childPath);
+					parseProps(item, childPath, limit, depth + 1, "" + i, out);
+				});
+				out.set(path, node);
+			} else if (
+				// Same for Map
+				maybeCollection &&
+				typeof data.name === "string" &&
+				data.type === "map"
+			) {
+				const children: any[] = [];
+				const node: PropData = {
+					depth,
+					name,
+					id: path,
+					type: "map",
+					editable: false,
+					value: data,
+					children,
+					meta: null,
+				};
 
-					(data.entries as any[]).forEach((item, i) => {
-						const childPath = `${path}.${i}`;
-						children.push(childPath);
-						parseProps(item, childPath, limit, depth + 1, "" + i, out);
-					});
-					out.set(path, node);
-				}
+				(data.entries as any[]).forEach((item, i) => {
+					const childPath = `${path}.${i}`;
+					children.push(childPath);
+					parseProps(item, childPath, limit, depth + 1, "" + i, out);
+				});
+				out.set(path, node);
 			} else if (
 				// Same for Blobs
 				maybeCustom &&


### PR DESCRIPTION
Hello 👋

I've been using preact-devtools as a way to inspect some state in my components and noticed that some state was causing the extension to act in an unexpected way.

When using an object that causes `maybeCollection` to evaluate as true (keys.length == 3 and the value for 'name' is of type `string`) the parseProps function does not return anything. One particular area this causes issues in is the parsing of hook data (See [parseHookData](https://github.com/preactjs/preact-devtools/blob/b51d117cfaa0d15dcaabc998fc61f301c806b265/src/adapter/10/renderer/hooks.ts#L176)).

![image](https://user-images.githubusercontent.com/13277581/137127372-322bbc1a-4cde-4fcc-8fc0-93251b9a86cf.png)

This PR breaks the two collection-like handlers apart so that the parsing function will fall back to the regular object handler as expected.