### PR TITLE
fix hook detection when the patch is under 1

### DIFF
--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -203,7 +203,7 @@ export function createHook(port: PortPageHook): DevtoolsHook {
 			if (preactVersionMatch.major == 10) {
 				const supports = {
 					renderReasons: !!config.Component,
-					hooks: preactVersionMatch.minor === 4 && preactVersionMatch.patch >= 1 || preactVersionMatch.minor > 4,
+					hooks: (preactVersionMatch.minor === 4 && preactVersionMatch.patch >= 1) || preactVersionMatch.minor > 4,
 				};
 
 				// Create an integer-based namespace to avoid clashing ids caused by

--- a/src/adapter/hook.ts
+++ b/src/adapter/hook.ts
@@ -203,7 +203,7 @@ export function createHook(port: PortPageHook): DevtoolsHook {
 			if (preactVersionMatch.major == 10) {
 				const supports = {
 					renderReasons: !!config.Component,
-					hooks: preactVersionMatch.minor >= 4 && preactVersionMatch.patch >= 1,
+					hooks: preactVersionMatch.minor === 4 && preactVersionMatch.patch >= 1 || preactVersionMatch.minor > 4,
 				};
 
 				// Create an integer-based namespace to avoid clashing ids caused by


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/3504

This currently happens for 10.7.0 because the patch is under 1