### PR TITLE
Fix highlight error if child is a placeholder

### DIFF
--- a/src/adapter/shared/traverse.ts
+++ b/src/adapter/shared/traverse.ts
@@ -48,10 +48,13 @@ function updateHighlight<T extends SharedVNode>(
 	bindings: PreactBindings<T>,
 ) {
 	if (profiler.highlightUpdates && bindings.isComponent(vnode)) {
-		const stack: any[] = [vnode];
+		const stack: Array<T | null | undefined> = [vnode];
 		let item;
 		let dom;
 		while ((item = stack.shift()) !== undefined) {
+			// Account for placholders/holes
+			if (item === null) continue;
+
 			if (!bindings.isComponent(item)) {
 				dom = bindings.getDom(item);
 				break;

--- a/test-e2e/fixtures/apps/holes.jsx
+++ b/test-e2e/fixtures/apps/holes.jsx
@@ -1,0 +1,19 @@
+import { h, render } from "preact";
+import { useState } from "preact/hooks";
+
+function Foo(props) {
+	return props.children;
+}
+
+function App() {
+	const [v, set] = useState(0);
+
+	return (
+		<Foo>
+			{v % 2 === 0 && "Not a placeholder"}
+			<button onClick={() => set(v + 1)}>Increment</button>
+		</Foo>
+	);
+}
+
+render(<App />, document.getElementById("app"));

--- a/test-e2e/tests/profiler/highlight-updates-holes.test.ts
+++ b/test-e2e/tests/profiler/highlight-updates-holes.test.ts
@@ -1,0 +1,26 @@
+import {
+	newTestPage,
+	click,
+	clickTab,
+	waitForSelector,
+} from "../../test-utils";
+import { expect } from "chai";
+import { clickSelector } from "pentf/browser_utils";
+
+export const description = "Check if highlight updates is rendered";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "holes");
+	await waitForSelector(page, "button");
+
+	await clickTab(devtools, "SETTINGS");
+	await click(devtools, '[data-testId="toggle-highlight-updates"]');
+
+	const errors: string[] = [];
+	page.on("pageerror", err => errors.push(err.toString()));
+
+	await clickSelector(page, "button");
+	await clickSelector(page, "button");
+
+	expect(errors).to.deep.equal([]);
+}


### PR DESCRIPTION
Missed a check for placeholder nodes. This didn't pop up earlier because the children array was typed as `any[]`.

Fixes #352 .