### PR TITLE
Profiler: Reduce number of DOM nodes

### DIFF
--- a/src/view/components/profiler/flamegraph/modes/FlamegraphLayout.tsx
+++ b/src/view/components/profiler/flamegraph/modes/FlamegraphLayout.tsx
@@ -49,7 +49,7 @@ export function FlamegraphLayout({
 				if (pos.commitParent || pos.weight === -1) {
 					text = (
 						<>
-							<span data-testid="node-name">{node.name}</span>
+							{node.name}
 							{filterHoc && node.hocs ? (
 								<HocLabels hocs={node.hocs} nodeId={node.id} canMark={false} />
 							) : (
@@ -62,7 +62,7 @@ export function FlamegraphLayout({
 					const total = formatTime(node.endTime - node.startTime);
 					text = (
 						<>
-							<span data-testid="node-name">{node.name}</span>
+							{node.name}
 							{filterHoc && node.hocs ? (
 								<HocLabels hocs={node.hocs} nodeId={node.id} canMark={false} />
 							) : (

--- a/test-e2e/tests/profiler/flamegraph/utils.ts
+++ b/test-e2e/tests/profiler/flamegraph/utils.ts
@@ -5,7 +5,7 @@ export async function getFlameNodes(page: Page) {
 		return els.map(el => {
 			return {
 				maximized: el.hasAttribute("data-maximized"),
-				name: el.querySelector('[data-testid="node-name"]')!.textContent || "",
+				name: el.getAttribute("data-name") || "",
 				visible: el.hasAttribute("data-visible"),
 			};
 		});


### PR DESCRIPTION
Revert part of #358 to reduce the number of DOM nodes in the Profiler view. The changes in #358 would slow down rendering quite a bit when a few thousand nodes are visible.

In the long term I'm hoping to switch to a canvas based renderer, but that's a bigger task and will take more time.