### PR TITLE
Resize static subtrees to available space

### DIFF
--- a/src/view/components/profiler/components/CommitTimeline/CommitTimeline.tsx
+++ b/src/view/components/profiler/components/CommitTimeline/CommitTimeline.tsx
@@ -141,7 +141,9 @@ export function CommitTimeline(props: CommitTimelineProps) {
 					<span class={s.hidden}>
 						{leading.slice(0, itemsCountLen - selectedCount.length)}
 					</span>
-					{selected + 1} / {items.length}
+					<span data-testid="commit-page-info">
+						{selected + 1} / {items.length}
+					</span>
 				</div>
 				<button
 					disabled={items.length <= 1}

--- a/test-e2e/fixtures/apps/static-subtree.jsx
+++ b/test-e2e/fixtures/apps/static-subtree.jsx
@@ -1,0 +1,46 @@
+import { h, render } from "preact";
+import { useState } from "preact/hooks";
+import { memo } from "preact/compat";
+
+function Display(props) {
+	blockFor(10);
+	return <div data-testid="result">Counter: {props.value}</div>;
+}
+
+function blockFor(ms) {
+	const start = Date.now();
+	while (Date.now() - start < ms) {
+		//
+	}
+}
+
+function Foo() {
+	blockFor(75);
+	return <p>Foo</p>;
+}
+
+function Static() {
+	blockFor(100);
+	return <Foo />;
+}
+
+const MemoStatic = memo(Static);
+
+function App() {
+	const [v, set] = useState(0);
+
+	blockFor(10);
+
+	return (
+		<div style="padding: 2rem;">
+			<MemoStatic key={v < 1 ? NaN : "1"} />
+			<Display key="2" value={v} />
+			<MemoStatic key={v < 1 ? NaN : "3"} />
+			<button key="4" onClick={() => set(v + 1)}>
+				Increment
+			</button>
+		</div>
+	);
+}
+
+render(<App />, document.getElementById("app"));

--- a/test-e2e/tests/profiler/flamegraph/profiler-static-subtree.test.ts
+++ b/test-e2e/tests/profiler/flamegraph/profiler-static-subtree.test.ts
@@ -1,0 +1,55 @@
+import { clickTestId } from "pentf/browser_utils";
+import { expect } from "chai";
+import {
+	newTestPage,
+	click,
+	clickTab,
+	clickRecordButton,
+	waitForSelector,
+} from "../../../test-utils";
+import { wait } from "pentf/utils";
+
+export const description = "Should work with filtered HOC roots";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "static-subtree");
+
+	await clickTab(devtools, "PROFILER");
+
+	await clickRecordButton(devtools);
+	await click(page, "button");
+	await wait(50);
+	await click(page, "button");
+	await clickRecordButton(devtools);
+
+	await waitForSelector(
+		devtools,
+		'[data-type="flamegraph"] [data-name="App"]',
+		{ timeout: 3000 },
+	);
+
+	await clickTestId(devtools, "next-commit", {
+		async retryUntil() {
+			return await devtools.evaluate(() => {
+				return (
+					document.querySelector('[data-testid="commit-page-info"]')!
+						.textContent === "2 / 2"
+				);
+			});
+		},
+	});
+
+	await wait(300);
+
+	const res = await devtools.evaluate(() => {
+		const display = document.querySelector('[data-name="Display"]')!
+			.clientWidth;
+		const statics = Array.from(
+			document.querySelectorAll('[data-name="Static"]')!,
+		).map(el => el.clientWidth);
+
+		return statics.every(w => w < display);
+	});
+
+	expect(res).to.equal(true, "Static nodes were bigger than Display");
+}


### PR DESCRIPTION
This ensures a better visual relationship between timings of nodes. Best explained with pictures.

Before:

<img width="573" alt="Screenshot 2022-05-21 at 10 13 08" src="https://user-images.githubusercontent.com/1062408/169642603-b56759f5-d788-4999-8896-4741efb23152.png">

After:

<img width="521" alt="Screenshot 2022-05-21 at 10 12 35" src="https://user-images.githubusercontent.com/1062408/169642607-e89e8d05-d1ae-4bb9-825a-1a98653415d6.png">
