### PR TITLE
Profiler(Ranked): Fix missing selection on commit change

### DIFF
--- a/test-e2e/fixtures/apps/profiler-2.jsx
+++ b/test-e2e/fixtures/apps/profiler-2.jsx
@@ -5,14 +5,13 @@ function Display(props) {
 	return <div data-testid="result">Counter: {props.value}</div>;
 }
 
-let i = 0;
-function Counter() {
+function Counter({ num }) {
 	const [v, set] = useState(0);
 
 	return (
 		<div style="padding: 2rem;">
 			<Display value={v} />
-			<button id={"counter-1" + i++} onClick={() => set(v + 1)}>
+			<button data-testid={"counter-" + num} onClick={() => set(v + 1)}>
 				Increment
 			</button>
 		</div>
@@ -23,7 +22,7 @@ function Foo() {
 	return (
 		<Fragment>
 			<div>foo</div>
-			<Counter />
+			<Counter num={2} />
 		</Fragment>
 	);
 }
@@ -31,7 +30,7 @@ function Foo() {
 function App() {
 	return (
 		<Fragment>
-			<Counter />
+			<Counter num={1} />
 			<Foo />
 		</Fragment>
 	);

--- a/test-e2e/tests/profiler/ranked/profiler-ranked-selected.test.ts
+++ b/test-e2e/tests/profiler/ranked/profiler-ranked-selected.test.ts
@@ -1,0 +1,31 @@
+import {
+	newTestPage,
+	click,
+	clickTab,
+	clickRecordButton,
+	waitForSelector,
+} from "../../../test-utils";
+import { clickSelector, clickTestId } from "pentf/browser_utils";
+
+export const description =
+	"Selected node should be changed across commits if not present";
+
+export async function run(config: any) {
+	const { page, devtools } = await newTestPage(config, "profiler-2");
+
+	await clickTab(devtools, "PROFILER");
+
+	await clickRecordButton(devtools);
+	await clickTestId(page, "counter-1");
+	await clickTestId(page, "counter-2");
+	await clickRecordButton(devtools);
+
+	await click(devtools, '[name="flamegraph_mode"][value="RANKED"]');
+	await clickSelector(devtools, '[data-name="Display"]');
+	await clickTestId(devtools, "next-commit");
+
+	await waitForSelector(
+		devtools,
+		'[data-type="ranked"] [data-selected="true"]',
+	);
+}


### PR DESCRIPTION
The currently selected node will not be reset when it's not part of the next commit in `ranked` profiler mode.