### PR TITLE
Fire indent on init in case resize is not fired

### DIFF
--- a/src/view/components/elements/useAutoIndent.ts
+++ b/src/view/components/elements/useAutoIndent.ts
@@ -10,12 +10,16 @@ export function useAutoIndent(container: RefObject<HTMLElement>, deps: any[]) {
 	const [available, setAvailable] = useState(0);
 	const cacheRef = useRef(new Map<string, number>());
 
-	useResize(() => {
-		indent.current = INITIAL;
-		if (container.current) {
-			setAvailable(container.current.clientWidth);
-		}
-	}, []);
+	useResize(
+		() => {
+			indent.current = INITIAL;
+			if (container.current) {
+				setAvailable(container.current.clientWidth);
+			}
+		},
+		[],
+		true,
+	);
 
 	useLayoutEffect(() => {
 		if (container.current) {


### PR DESCRIPTION
Still unable to reproduce it on my end, but this should ensure that at least the initial size is correct in case no `resize` event is fired.

Another attempt at resolving #387 . 