### PR TITLE
Fix hooks inspection not working with 10.8.1

### DIFF
--- a/src/adapter/11/bindings.ts
+++ b/src/adapter/11/bindings.ts
@@ -243,7 +243,7 @@ export function getHookState(
 				? provider.props.value
 				: context._defaultValue || context.__;
 		}
-		const value = list[index]._value || list[index].__;
+		const value = getPendingHookValue(list[index]);
 
 		if (type === HookType.useRef) {
 			return value[0].current;
@@ -255,6 +255,18 @@ export function getHookState(
 	}
 
 	return [];
+}
+
+export function getPendingHookValue(state: HookState) {
+	return state._value !== undefined ? state._value : state.__;
+}
+
+export function setPendingHookValue(state: HookState, value: unknown) {
+	if ("_value" in state) {
+		state._value = value;
+	} else {
+		state.__ = value;
+	}
 }
 
 export function createSuspenseState(vnode: Internal, suspended: boolean) {
@@ -297,6 +309,8 @@ export const bindingsV11: PreactBindings<Internal> = {
 	getComponent,
 	getComponentHooks,
 	getHookState,
+	getPendingHookValue,
+	setPendingHookValue,
 	getVNodeParent,
 	isComponent,
 	isElement,

--- a/src/adapter/shared/bindings.ts
+++ b/src/adapter/shared/bindings.ts
@@ -40,6 +40,8 @@ export interface PreactBindings<T extends SharedVNode = SharedVNode> {
 	getStatefulHooks(vnode: T): HookState[] | null;
 	isUseReducerOrState(state: HookState): boolean;
 	getStatefulHookValue(state: HookState): unknown;
+	setPendingHookValue(state: HookState, value: unknown): void;
+	getPendingHookValue(state: HookState): unknown;
 
 	// Profiler related
 	getRenderReasonPost(


### PR DESCRIPTION
With the recent change in https://github.com/preactjs/preact/pull/3567 the rendering of stateful hooks changed a little. This PR updates our detection code for that.

Related https://github.com/preactjs/preact/pull/3575