### PR TITLE
Fix wrong record icon

### DIFF
--- a/src/view/sprite.svg
+++ b/src/view/sprite.svg
@@ -70,7 +70,7 @@
 	</symbol>
 
 	<symbol id="record-icon" viewBox="0 0 24 24">
-		<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31C15.55 19.37 13.85 20 12 20zm6.31-3.1L7.1 5.69C8.45 4.63 10.15 4 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z" fill="currentColor" />
+		<circle fill="currentColor" cx="12" cy="12" r="8" />
 	</symbol>
 
 	<symbol id="not-interested" viewBox="0 0 24 24">


### PR DESCRIPTION
This is an error caused by the recent icon refactoring. It's only on `main` and not in a released version.