### PR TITLE
Fix incorrect highlight bounds checks

### DIFF
--- a/src/adapter/dom.ts
+++ b/src/adapter/dom.ts
@@ -34,31 +34,20 @@ export interface Measurements {
 	};
 }
 
-function getBoundsState(rect: {
-	top: number;
-	height: number;
-	left: number;
-	width: number;
-}) {
-	return {
-		top: rect.top + window.pageYOffset < window.scrollY,
-		bottom: rect.top + rect.height > window.innerHeight + scrollY,
-		left: rect.left + window.pageXOffset < window.scrollX,
-		right: rect.left + rect.width > window.scrollX + window.innerWidth,
-	};
-}
-
 export function measureNode(dom: Element): Measurements {
 	const s = window.getComputedStyle(dom);
 	const r = dom.getBoundingClientRect();
 
-	const top = r.top + window.pageYOffset;
-	const left = r.left + window.pageXOffset;
-
 	return {
-		top,
-		left,
-		bounds: getBoundsState(r),
+		top: r.top + window.scrollY,
+		left: r.left + window.scrollX,
+		// Attention: getBoundingClientRect() is relative to the viewport.
+		bounds: {
+			top: r.top + r.height <= 0,
+			bottom: r.top >= window.innerHeight,
+			left: r.left + r.width <= 0,
+			right: r.left >= window.innerWidth,
+		},
 		boxSizing: s.boxSizing,
 
 		// Round to at most 2 decimals. This is not 100% accurate,
@@ -90,12 +79,13 @@ export function mergeMeasure(a: Measurements, b: Measurements): Measurements {
 		boxSizing: a.boxSizing,
 		top,
 		left,
-		bounds: getBoundsState({
-			height,
-			left,
-			top,
-			width,
-		}),
+		// Attention: We're dealing with absolute coordinates here
+		bounds: {
+			top: top + height <= window.scrollY,
+			bottom: top >= window.scrollY + window.innerHeight,
+			left: left + width <= window.scrollX,
+			right: left >= window.scrollX + window.innerWidth,
+		},
 		width,
 		height,
 

--- a/test-e2e/tests/highlight-iframe.test.ts
+++ b/test-e2e/tests/highlight-iframe.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { gotoTest, wait } from "../pw-utils";
 
-test.only("Highlight iframe nodes", async ({ page }) => {
+test("Highlight iframe nodes", async ({ page }) => {
 	const { devtools } = await gotoTest(page, "iframe");
 
 	await devtools


### PR DESCRIPTION
This was caused by a confusion between viewport relative and absolute coordinates.