### PR TITLE
Add support for loading preact from local repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
 		"test": "mochette -c tsconfig.cjs.json 'src/**/*.test.{ts,tsx}'",
 		"test:e2e": "node tools/fetch-preact-versions.mjs && playwright test",
 		"test:e2e:10": "PREACT_VERSION=10 npm run test:e2e",
+		"test:e2e:11": "PREACT_VERSION=11 npm run test:e2e",
+		"test:e2e:git": "PREACT_VERSION=git npm run test:e2e",
 		"test:e2e:all": "npm run test:e2e && npm run test:e2e:10",
 		"dev": "npm run dev:serve",
 		"dev:serve": "vite test-e2e/fixtures --port 8100",

--- a/test-e2e/fixtures/utils.ts
+++ b/test-e2e/fixtures/utils.ts
@@ -6,7 +6,7 @@ import fs from "fs";
  */
 export function getPreactVersions() {
 	const dir = path.join(__dirname, "vendor", "preact");
-	return fs
+	const versions = fs
 		.readdirSync(dir)
 		.filter(name => !name.startsWith("."))
 		.map(name => {
@@ -50,4 +50,6 @@ export function getPreactVersions() {
 			// Check if is tagged release: 11.0.0-experimental.0
 			return a.localeCompare(b) * -1;
 		});
+
+	return ["git", ...versions];
 }


### PR DESCRIPTION
This works when the `preact` repository is in the same parent folder as the one for `preact-devtools`.