### PR TITLE
Improve perf of diffed hook

### DIFF
--- a/src/adapter/marks.ts
+++ b/src/adapter/marks.ts
@@ -19,12 +19,14 @@ export function endMark(nodeName: string) {
 		const name = markName(nodeName);
 		const start = `${name}_diff`;
 		const end = `${name}_diffed`;
-		if (performance.getEntriesByName(start).length > 0) {
+		try {
 			performance.mark(end);
 			performance.measure(name, start, end);
+
+			performance.clearMarks(start);
+			performance.clearMarks(end);
+		} catch (e) {
+			// Do nothing
 		}
-		performance.clearMarks(start);
-		performance.clearMarks(end);
-		performance.clearMeasures(name);
 	}
 }


### PR DESCRIPTION
I've noticed in browser traces at work that the devtools extension is showing up a lot in traces and is causing jank in our page. While it doesn't affect users, I don't want my team to get the wrong impressions about Preact's perf when they are browsing localhost with devtools installed. So this change is attempting to improve the perf of devtools hooks so that it doesn't impact the page.

Sample screenshot of what I see in browser traces:
<img width="766" alt="Screenshot 2023-01-27 at 2 56 36 PM" src="https://user-images.githubusercontent.com/459878/215225726-6897a008-872d-4de6-8bb6-56b65b1be349.png">
