### PR TITLE
Fixes bug in grid-areas.

### DIFF
--- a/tools/build-plugins/esbuild-plugins.mjs
+++ b/tools/build-plugins/esbuild-plugins.mjs
@@ -232,7 +232,7 @@ export function cssModules() {
 
 		// Fix CSS grid areas treated as local
 		css = css
-			.replaceAll(/grid-area:\s+[^_]+_(.*?);$/gm, (m, g) => {
+			.replaceAll(/grid-area:\s+_?[^_]+_(.*?);$/gm, (m, g) => {
 				return `grid-area: ${g};`;
 			})
 			.replaceAll(/\s["][^"']+_([^"']+)["]/g, (m, g) => {


### PR DESCRIPTION
I don't really understand why the build is doing name mangling of classes and grid areas, but it appears there is already some code to deal with it. Unfortunately, that code doesn't work as *sometimes* the name mangler is including a leading `_` and sometimes it is not. Luckily, the fix is easy, just include support for an optional leading `_` in the existing regexp.