### PR TITLE
Fix crash when inspecting signal hooks

### DIFF
--- a/src/adapter/shared/hooks.ts
+++ b/src/adapter/shared/hooks.ts
@@ -332,6 +332,10 @@ export function inspectHooks<T extends SharedVNode>(
 				c.constructor.call(dummy, dummy.props, dummy.context);
 			}
 		}
+
+		// Signals need this, otherwise they end up in an incosnistent state
+		const diffedHook = options.diffed;
+		if (diffedHook) diffedHook(vnode as any);
 	} catch (error) {
 		// We don't care about any errors here. We only need
 		// the hook call sites


### PR DESCRIPTION
Hooks inspection does a faked render (similar to React) to be able to detect custom hooks. Because we were calling an incomplete set of option hooks this lead to the internal state in the signals addon referencing the wrong vnodes.

Fixes #456