### PR TITLE
Revert back to Manifest V2

### DIFF
--- a/src/shells/chrome/manifest.json
+++ b/src/shells/chrome/manifest.json
@@ -1,14 +1,11 @@
 {
-	"manifest_version": 3,
+	"manifest_version": 2,
 	"name": "Preact Developer Tools",
 	"description": "Adds debugging tools for Preact to Chrome",
 	"version": "4.6.1",
 	"devtools_page": "panel/empty-panel.html",
-	"content_security_policy": {
-		"extension_pages": "script-src 'self'; object-src 'self'"
-	},
-	"permissions": ["storage", "scripting"],
-	"host_permissions": ["<all_urls>"],
+	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+	"permissions": ["file:///*", "http://*/*", "https://*/*", "storage"],
 	"icons": {
 		"16": "icons/icon-16.png",
 		"32": "icons/icon-32.png",
@@ -16,7 +13,7 @@
 		"128": "icons/icon-128.png",
 		"192": "icons/icon-192.png"
 	},
-	"action": {
+	"browser_action": {
 		"default_icon": {
 			"16": "icons/icon-16-disabled.png",
 			"32": "icons/icon-32-disabled.png",
@@ -27,7 +24,8 @@
 		"default_popup": "popup/disabled.html"
 	},
 	"background": {
-		"service_worker": "background/background.js"
+		"scripts": ["background/background.js"],
+		"persistent": false
 	},
 	"content_scripts": [
 		{
@@ -37,11 +35,5 @@
 			"run_at": "document_start"
 		}
 	],
-	"web_accessible_resources": [
-		{
-			"resources": ["preact-devtools-page.css"],
-			"matches": ["<all_urls>"],
-			"extension_ids": ["ilcajpmogmhpliinlbcdebhbcanbghmd"]
-		}
-	]
+	"web_accessible_resources": ["preact-devtools-page.css"]
 }

--- a/src/shells/edge/manifest.json
+++ b/src/shells/edge/manifest.json
@@ -1,14 +1,11 @@
 {
-	"manifest_version": 3,
+	"manifest_version": 2,
 	"name": "Preact Developer Tools",
 	"description": "Adds debugging tools for Preact to Microsoft Edge",
 	"version": "4.6.1",
 	"devtools_page": "panel/empty-panel.html",
-	"content_security_policy": {
-		"extension_pages": "script-src 'self'; object-src 'self'"
-	},
-	"permissions": ["storage", "scripting"],
-	"host_permissions": ["<all_urls>"],
+	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+	"permissions": ["file:///*", "http://*/*", "https://*/*", "storage"],
 	"icons": {
 		"16": "icons/icon-16.png",
 		"32": "icons/icon-32.png",
@@ -16,7 +13,7 @@
 		"128": "icons/icon-128.png",
 		"192": "icons/icon-192.png"
 	},
-	"action": {
+	"browser_action": {
 		"default_icon": {
 			"16": "icons/icon-16-disabled.png",
 			"32": "icons/icon-32-disabled.png",
@@ -27,7 +24,8 @@
 		"default_popup": "popup/disabled.html"
 	},
 	"background": {
-		"service_worker": "background/background.js"
+		"scripts": ["background/background.js"],
+		"persistent": false
 	},
 	"content_scripts": [
 		{
@@ -37,11 +35,5 @@
 			"run_at": "document_start"
 		}
 	],
-	"web_accessible_resources": [
-		{
-			"resources": ["preact-devtools-page.css", "installHook.js"],
-			"matches": ["<all_urls>"],
-			"extension_ids": []
-		}
-	]
+	"web_accessible_resources": ["preact-devtools-page.css"]
 }

--- a/src/shells/shared/background/background.ts
+++ b/src/shells/shared/background/background.ts
@@ -7,20 +7,6 @@ import {
 } from "../../../constants";
 import { BaseEvent } from "../../../adapter/adapter/port";
 import { BackgroundEmitter, Emitter } from "./emitter";
-import { isFirefox } from "../utils";
-
-const IS_FIREFOX = isFirefox();
-if (!IS_FIREFOX) {
-	chrome.scripting.registerContentScripts([
-		{
-			id: "hook",
-			matches: ["<all_urls>"],
-			js: ["installHook.js"],
-			runAt: "document_start",
-			world: (chrome.scripting as any).ExecutionWorld.MAIN,
-		},
-	]);
-}
 
 /**
  * Collection of potential targets to connect to by tabId.

--- a/src/shells/shared/content-script.ts
+++ b/src/shells/shared/content-script.ts
@@ -99,8 +99,5 @@ if (document.contentType === "text/html") {
 	// See: https://github.com/preactjs/preact-devtools/issues/85
 	//
 	// The string "CODE_TO_INJECT" will be replaced by our build tool.
-	if (process.env.BROWSER === "firefox") {
-		debug("Firefox injection enabled");
-		inject(`;(${"CODE_TO_INJECT"}(window))`, "code");
-	}
+	inject(`;(${"CODE_TO_INJECT"}(window))`, "code");
 }

--- a/src/shells/shared/popup/popup.ts
+++ b/src/shells/shared/popup/popup.ts
@@ -2,13 +2,6 @@
 // the background page to activate or deactivate the icon
 
 import { debug } from "../../../debug";
-import { isFirefox } from "../utils";
-
-const IS_FIREFOX = isFirefox();
-function getUrl(url: string) {
-	if (IS_FIREFOX) return url;
-	return chrome.runtime.getURL(url);
-}
 
 export function setPopupStatus(tabId: number, enabled?: boolean) {
 	const status = enabled ? "enabled" : "disabled";
@@ -19,18 +12,18 @@ export function setPopupStatus(tabId: number, enabled?: boolean) {
 	);
 	const suffix = enabled ? "" : "-disabled";
 
-	(IS_FIREFOX ? chrome.browserAction : chrome.action).setIcon({
+	chrome.browserAction.setIcon({
 		tabId,
 		path: {
-			"16": getUrl(`icons/icon-16${suffix}.png`),
-			"32": getUrl(`icons/icon-32${suffix}.png`),
-			"48": getUrl(`icons/icon-48${suffix}.png`),
-			"128": getUrl(`icons/icon-128${suffix}.png`),
-			"192": getUrl(`icons/icon-192${suffix}.png`),
+			"16": `icons/icon-16${suffix}.png`,
+			"32": `icons/icon-32${suffix}.png`,
+			"48": `icons/icon-48${suffix}.png`,
+			"128": `icons/icon-128${suffix}.png`,
+			"192": `icons/icon-192${suffix}.png`,
 		},
 	});
-	(IS_FIREFOX ? chrome.browserAction : chrome.action).setPopup({
+	chrome.browserAction.setPopup({
 		tabId,
-		popup: getUrl(`popup/${status}.html`),
+		popup: `popup/${status}.html`,
 	});
 }

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -150,7 +150,7 @@ async function build(browser) {
 				renamePlugin({
 					[`${dist}/installHook.css`]: `${dist}/preact-devtools-page.css`,
 				}),
-			!isInline && browser === "firefox" && inlineHookPlugin(dist),
+			!isInline && inlineHookPlugin(dist),
 
 			spritePlugin(
 				path.join(__dirname, "..", "src", "view", "sprite.svg"),


### PR DESCRIPTION
There are two key factors which make me very worried about moving to MV3:

1. MV3 Service worker breaks on auto update https://bugs.chromium.org/p/chromium/issues/detail?id=1271154#c81 - Still not fixed
2. Google having laid off a bunch of folks from the extension team
3. Google itself has [extended the MV2 support lifecycle](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/) which kinda hints that MV3 is not ready.

Overall, I'm very hesitant to be one of the early adopters as I can't afford the additional cost of maintenance and debugging of weird issues that the move to MV3 would likely entail. Happy to try again once MV3 is more stable.