### PR TITLE
Always infer debug mode from flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"build:inline": "node tools/build.mjs --browser inline && tsc -p tsconfig.inline.json",
 		"archive": "git archive --format zip --output dist/source-code.zip main",
 		"lint": "eslint 'src/**/*.{ts,tsx}' 'test-e2e/**/*.ts'",
-		"test": "mochette -c tsconfig.cjs.json 'src/**/*.test.{ts,tsx}'",
+		"test": "mochette -c tsconfig.cjs.json -r tools/test-setup.js 'src/**/*.test.{ts,tsx}'",
 		"test:e2e": "node tools/fetch-preact-versions.mjs && playwright test",
 		"test:e2e:10": "PREACT_VERSION=10 npm run test:e2e",
 		"test:e2e:11": "PREACT_VERSION=11 npm run test:e2e",

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -2,7 +2,7 @@
  * Will be tree-shaken out in prod builds
  */
 export function debug(...args: any[]) {
-	if (process.env.DEBUG) {
+	if (__DEBUG__) {
 		// eslint-disable-next-line no-console
 		console.log(...args);
 	}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,3 +6,5 @@ declare module "*.css" {
 declare module "@preact-list-versions" {
 	export const preactVersions: string[];
 }
+
+declare const __DEBUG__: boolean;

--- a/src/shells/shared/panel/panel.ts
+++ b/src/shells/shared/panel/panel.ts
@@ -90,7 +90,7 @@ async function initDevtools() {
 	effect(() => storeHighlightUpdates(store.profiler.highlightUpdates.value));
 	effect(() => storeDebugMode(store.debugMode.value));
 
-	if (process.env.DEBUG) {
+	if (__DEBUG__) {
 		(window as any).store = store;
 	}
 

--- a/src/view/store/index.ts
+++ b/src/view/store/index.ts
@@ -17,7 +17,7 @@ export function createStore(): Store {
 		listeners.forEach(fn => fn && fn(name, data));
 	};
 
-	const debugMode = signal(!!process.env.DEBUG);
+	const debugMode = signal(!!__DEBUG__);
 
 	const nodes = signal<Map<ID, DevNode>>(new Map());
 	const roots = signal<ID[]>([]);

--- a/test-e2e/fixtures/vite.config.ts
+++ b/test-e2e/fixtures/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
 						jsxFragment: "Fragment",
 						jsxInject: "",
 						define: {
-							"process.env.DEBUG": JSON.stringify(false),
+							__DEBUG__: JSON.stringify(false),
 						},
 					},
 

--- a/tools/build-plugins/esbuild-plugins.mjs
+++ b/tools/build-plugins/esbuild-plugins.mjs
@@ -158,9 +158,10 @@ export function inlineHookPlugin(dir) {
 /**
  * @param {string} dir
  * @param {string} browser
+ * @param {boolean} debug
  * @returns {import("esbuild").Plugin}
  */
-export function archivePlugin(dir, browser) {
+export function archivePlugin(dir, browser, debug) {
 	return {
 		name: "archive-plugin",
 		setup(build) {
@@ -169,7 +170,7 @@ export function archivePlugin(dir, browser) {
 
 				// Package extension
 				const output = fsSync.createWriteStream(
-					path.join(dir, `${browser}.zip`),
+					path.join(dir, `${browser}${debug ? "-debug" : ""}.zip`),
 				);
 				const archive = archiver("zip", { zlib: { level: 9 } });
 

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -161,7 +161,7 @@ async function build(browser) {
 							path.join(dist, "panel", "empty-panel.html"),
 					  ],
 			),
-			!isInline && archivePlugin("dist", browser),
+			!isInline && archivePlugin("dist", browser, DEBUG),
 			!isInline && !process.env.CI && gitSourcePlugin(),
 		].filter(Boolean),
 	});

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -79,7 +79,7 @@ async function run() {
 run();
 
 async function build(browser) {
-	const dist = `dist/${browser}`;
+	const dist = `dist/${browser}${DEBUG ? "-debug" : ""}`;
 	// eslint-disable-next-line no-console
 	console.log(`${kl.dim("Browser:")} ${kl.cyan(browser)}`);
 	const start = Date.now();

--- a/tools/build.mjs
+++ b/tools/build.mjs
@@ -102,7 +102,7 @@ async function build(browser) {
 	}
 
 	const define = {
-		"process.env.DEBUG": DEBUG,
+		__DEBUG__: DEBUG,
 		"process.env.BROWSER": JSON.stringify(browser),
 	};
 

--- a/tools/test-setup.js
+++ b/tools/test-setup.js
@@ -1,0 +1,1 @@
+global.__DEBUG__ = false;


### PR DESCRIPTION
I can't exactly reconstruct why I accidentally uploaded a debug build for chrome yesterday when cutting a new version (see https://github.com/preactjs/preact-devtools/issues/467 ). My assumption is that I ran the `run:chrome` command which builds a debug extension and loads it into a fresh chrome instance. I typically always use that just before publishing to make a final smoke test check. Normally, I run the `build:chrome` command once that's done but it looks like I forgot that yesterday. That's very likely what happened yesterday.

To prevent such accidents in the future this PR makes a couple of changes:

- Always use separate directories for debug and non-debug builds
- Always add `-debug` suffix to zipped debug extensions
- Use a global variable that must be injected to toggle debug mode instead of relying on `process.env.DEBUG`