### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/test-e2e/tests/profiler/flamegraph/highlight-flamegraph.test.ts
+++ b/test-e2e/tests/profiler/flamegraph/highlight-flamegraph.test.ts
@@ -17,7 +17,7 @@ test("Should highlight flamegraph node if present in DOM", async ({ page }) => {
 
 	await devtools.locator(locateFlame("Counter")).first().hover();
 	// Wait for possible flickering to occur
-	await wait(1000);
+	await wait(500);
 
 	const log = (await page.evaluate(() => (window as any).log)) as any[];
 	expect(log.filter(x => x.type === "highlight").length).toEqual(1);


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 1000ms to 500ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.