### PR TITLE
Remove tabs permission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "preact-devtools",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "preact-devtools",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "Preact Devtools Extension",
 	"main": "dist/preact-devtools.js",
 	"module": "dist/preact-devtools.module.js",

--- a/src/shells/chrome/manifest.json
+++ b/src/shells/chrome/manifest.json
@@ -7,7 +7,7 @@
 	"content_security_policy": {
 		"extension_pages": "script-src 'self'; object-src 'self'"
 	},
-	"permissions": ["scripting", "storage", "tabs"],
+	"permissions": ["scripting", "storage"],
 	"optional_permissions": ["clipboardWrite"],
 	"host_permissions": ["<all_urls>"],
 	"icons": {

--- a/src/shells/chrome/manifest.json
+++ b/src/shells/chrome/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Preact Developer Tools",
 	"description": "Adds debugging tools for Preact to Chrome",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"devtools_page": "panel/empty-panel.html",
 	"content_security_policy": {
 		"extension_pages": "script-src 'self'; object-src 'self'"

--- a/src/shells/edge/manifest.json
+++ b/src/shells/edge/manifest.json
@@ -7,7 +7,7 @@
 	"content_security_policy": {
 		"extension_pages": "script-src 'self'; object-src 'self'"
 	},
-	"permissions": ["scripting", "storage", "tabs"],
+	"permissions": ["scripting", "storage"],
 	"optional_permissions": ["clipboardWrite"],
 	"host_permissions": ["<all_urls>"],
 	"icons": {

--- a/src/shells/edge/manifest.json
+++ b/src/shells/edge/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Preact Developer Tools",
 	"description": "Adds debugging tools for Preact to Microsoft Edge",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"devtools_page": "panel/empty-panel.html",
 	"content_security_policy": {
 		"extension_pages": "script-src 'self'; object-src 'self'"

--- a/src/shells/firefox/manifest.json
+++ b/src/shells/firefox/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Preact Developer Tools",
 	"description": "Adds debugging tools for Preact to Firefox",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"devtools_page": "panel/empty-panel.html",
 	"content_security_policy": {
 		"extension_pages": "script-src 'self'; object-src 'self'"

--- a/src/shells/firefox/manifest.json
+++ b/src/shells/firefox/manifest.json
@@ -7,7 +7,7 @@
 	"content_security_policy": {
 		"extension_pages": "script-src 'self'; object-src 'self'"
 	},
-	"permissions": ["scripting", "storage", "tabs"],
+	"permissions": ["scripting", "storage"],
 	"optional_permissions": ["clipboardWrite"],
 	"host_permissions": ["<all_urls>"],
 	"browser_specific_settings": {


### PR DESCRIPTION
Latest attempt to update the extension was rejected due to the `tabs` permission. It looks like it's not needed and I'm not sure why I've added it. Probably a leftover when trying to wrestle MV3.