### PR TITLE
fix: Ref types ahead of v11 making them stricter

### DIFF
--- a/src/view/components/elements/VirtualizedList.tsx
+++ b/src/view/components/elements/VirtualizedList.tsx
@@ -10,7 +10,7 @@ import { useResize } from "../utils";
 
 export interface VirtualizedListProps<T> {
 	items: T[];
-	container: RefObject<Element>;
+	container: RefObject<Element | null>;
 	rowHeight: number;
 	minBufferCount: number;
 	renderRow: (item: T, idx: number, top: number) => any;

--- a/src/view/components/elements/useAutoIndent.ts
+++ b/src/view/components/elements/useAutoIndent.ts
@@ -5,7 +5,10 @@ import { useResize } from "../utils";
 const INITIAL = 14;
 const RIGHT_MARGIN = 16;
 
-export function useAutoIndent(container: RefObject<HTMLElement>, deps: any[]) {
+export function useAutoIndent(
+	container: RefObject<HTMLElement | null>,
+	deps: any[],
+) {
 	const indent = useRef(INITIAL);
 	const [available, setAvailable] = useState(0);
 	const cacheRef = useRef(new Map<string, number>());

--- a/src/view/components/profiler/components/CommitTimeline/CommitTimeline.tsx
+++ b/src/view/components/profiler/components/CommitTimeline/CommitTimeline.tsx
@@ -5,10 +5,10 @@ import { useResize } from "../../../utils";
 import { Icon } from "../../../icons";
 
 function calcSize(
-	container: RefObject<HTMLDivElement>,
-	inner: RefObject<HTMLDivElement>,
-	pane: RefObject<HTMLDivElement>,
-	paneContainer: RefObject<HTMLDivElement>,
+	container: RefObject<HTMLDivElement | null>,
+	inner: RefObject<HTMLDivElement | null>,
+	pane: RefObject<HTMLDivElement | null>,
+	paneContainer: RefObject<HTMLDivElement | null>,
 	count: number,
 	selected: number,
 ) {


### PR DESCRIPTION
Re: https://github.com/preactjs/preact/pull/4683

In X (and past React versions), ref types were a bit loose in that `RefObject<HTMLDivElement | null>` could satisfy `RefObject<HMTLDivElement>` -- this really shouldn't have been the case. We've corrected this in v11 via the PR linked above.