### PR TITLE
fix: ts error Type 'Element | Text' is not assignable to type 'Element'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "preact-devtools",
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"errorstacks": "^2.4.1",

--- a/src/adapter/dom.ts
+++ b/src/adapter/dom.ts
@@ -1,7 +1,9 @@
 import { NodeType } from "../constants";
 
 export function getNearestElement(dom: Element | Text): Element {
-	return dom.nodeType === NodeType.Text ? (dom.parentNode as any) : dom;
+	return dom.nodeType === NodeType.Text
+		? (dom.parentNode as any)
+		: (dom as Element);
 }
 
 export function px2Int(input: string | null) {


### PR DESCRIPTION
Recently, we changed our repository's package manager from yarn to npm (fc60d50924f2d38d23b6a86004b710478874752d), which caused our typescript version to change from **5.4.5** to **5.8.2**, because we specified the version in package.json with `"typescript": "^5.4.5"`. Under 5.8.2, an error will be reported here, and `tsc --noEmit` will fail.

```bash
$ npx tsc --noEmit 
src/adapter/dom.ts:4:68 - error TS2322: Type 'Element | Text' is not assignable to type 'Element'.
  Type 'Text' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 116 more.

4  return dom.nodeType === NodeType.Text ? (dom.parentNode as any) : dom;
                                                                     ~~~


Found 1 error in src/adapter/dom.ts:4
```
