### PR TITLE
fix: potential memory leak due to growing string table

### DIFF
--- a/src/adapter/protocol/string-table.test.ts
+++ b/src/adapter/protocol/string-table.test.ts
@@ -1,4 +1,9 @@
-import { parseTable, flushTable } from "./string-table";
+import {
+	ENCODE_CACHE_LIMIT,
+	encode,
+	parseTable,
+	flushTable,
+} from "./string-table";
 import { expect } from "chai";
 
 describe("StringTable", () => {
@@ -9,15 +14,7 @@ describe("StringTable", () => {
 				["foo", 2],
 			]);
 			expect(flushTable(table)).to.deep.equal([
-				8,
-				3,
-				97,
-				98,
-				99,
-				3,
-				102,
-				111,
-				111,
+				8, 3, 97, 98, 99, 3, 102, 111, 111,
 			]);
 		});
 	});
@@ -31,6 +28,42 @@ describe("StringTable", () => {
 		it("should parse multiple strings", () => {
 			const data = [8, 3, 97, 98, 99, 3, 102, 111, 111];
 			expect(parseTable(data)).to.deep.equal(["abc", "foo"]);
+		});
+	});
+
+	describe("encode", () => {
+		it("should preserve NUL characters", () => {
+			expect(parseTable([2, 1, ...encode("\0")])).to.deep.equal(["\0"]);
+		});
+
+		it("should reuse cached strings", () => {
+			const encoded = encode("cached-string");
+			expect(encode("cached-string")).to.equal(encoded);
+		});
+
+		it("should evict the least recently used string", () => {
+			const prefix = "evict-lru";
+			const encoded = encode(prefix);
+
+			for (let i = 0; i < ENCODE_CACHE_LIMIT; i++) {
+				encode(`${prefix}-${i}`);
+			}
+
+			expect(encode(prefix)).to.not.equal(encoded);
+		});
+
+		it("should refresh a string when it is read from the cache", () => {
+			const prefix = "refresh-lru";
+			const encoded = encode(prefix);
+
+			for (let i = 0; i < ENCODE_CACHE_LIMIT - 1; i++) {
+				encode(`${prefix}-${i}`);
+			}
+
+			expect(encode(prefix)).to.equal(encoded);
+			encode(`${prefix}-overflow`);
+
+			expect(encode(prefix)).to.equal(encoded);
 		});
 	});
 });

--- a/src/adapter/protocol/string-table.test.ts
+++ b/src/adapter/protocol/string-table.test.ts
@@ -1,5 +1,6 @@
 import {
 	ENCODE_CACHE_LIMIT,
+	LRUCache,
 	encode,
 	parseTable,
 	flushTable,
@@ -28,6 +29,60 @@ describe("StringTable", () => {
 		it("should parse multiple strings", () => {
 			const data = [8, 3, 97, 98, 99, 3, 102, 111, 111];
 			expect(parseTable(data)).to.deep.equal(["abc", "foo"]);
+		});
+	});
+
+	describe("LRUCache", () => {
+		it("should return undefined for missing entries", () => {
+			const cache = new LRUCache<string, number>(2);
+
+			expect(cache.get("missing")).to.equal(undefined);
+		});
+
+		it("should store and read entries", () => {
+			const cache = new LRUCache<string, number>(2);
+
+			cache.set("a", 1);
+
+			expect(cache.get("a")).to.equal(1);
+		});
+
+		it("should evict the oldest entry when the limit is exceeded", () => {
+			const cache = new LRUCache<string, number>(2);
+
+			cache.set("a", 1);
+			cache.set("b", 2);
+			cache.set("c", 3);
+
+			expect(cache.get("a")).to.equal(undefined);
+			expect(cache.get("b")).to.equal(2);
+			expect(cache.get("c")).to.equal(3);
+		});
+
+		it("should refresh recency when an entry is read", () => {
+			const cache = new LRUCache<string, number>(2);
+
+			cache.set("a", 1);
+			cache.set("b", 2);
+			expect(cache.get("a")).to.equal(1);
+			cache.set("c", 3);
+
+			expect(cache.get("a")).to.equal(1);
+			expect(cache.get("b")).to.equal(undefined);
+			expect(cache.get("c")).to.equal(3);
+		});
+
+		it("should refresh recency when an existing entry is written", () => {
+			const cache = new LRUCache<string, number>(2);
+
+			cache.set("a", 1);
+			cache.set("b", 2);
+			cache.set("a", 3);
+			cache.set("c", 4);
+
+			expect(cache.get("a")).to.equal(3);
+			expect(cache.get("b")).to.equal(undefined);
+			expect(cache.get("c")).to.equal(4);
 		});
 	});
 

--- a/src/adapter/protocol/string-table.ts
+++ b/src/adapter/protocol/string-table.ts
@@ -22,7 +22,7 @@ export function getStringId(table: StringTable, input: string): number {
 
 export const ENCODE_CACHE_LIMIT = 1000;
 
-class LRUCache<K, V> {
+export class LRUCache<K, V> {
 	private cache = new Map<K, V>();
 
 	constructor(private limit: number) {}

--- a/src/adapter/protocol/string-table.ts
+++ b/src/adapter/protocol/string-table.ts
@@ -20,19 +20,55 @@ export function getStringId(table: StringTable, input: string): number {
 	return table.get(input)!;
 }
 
-// TODO: Use a proper LRU cache?
-const encoded = new Map<string, number[]>();
+export const ENCODE_CACHE_LIMIT = 1000;
 
-const toCodePoint = (s: string) => s.codePointAt(0) || 124; // "|"" symbol;
+class LRUCache<K, V> {
+	private cache = new Map<K, V>();
+
+	constructor(private limit: number) {}
+
+	get(key: K): V | undefined {
+		const value = this.cache.get(key);
+		if (value === undefined) return undefined;
+
+		this.cache.delete(key);
+		this.cache.set(key, value);
+		return value;
+	}
+
+	set(key: K, value: V) {
+		if (this.cache.has(key)) {
+			this.cache.delete(key);
+		}
+
+		this.cache.set(key, value);
+
+		if (this.cache.size > this.limit) {
+			const oldest = this.cache.keys().next().value;
+			if (oldest !== undefined) {
+				this.cache.delete(oldest);
+			}
+		}
+	}
+}
+
+const encoded = new LRUCache<string, number[]>(ENCODE_CACHE_LIMIT);
 
 /**
  * Convert a string to an array of codepoints
  */
 export function encode(input: string): number[] {
-	if (!encoded.has(input)) {
-		encoded.set(input, input.split("").map(toCodePoint));
+	const cached = encoded.get(input);
+	if (cached !== undefined) {
+		return cached;
 	}
-	return encoded.get(input)!;
+
+	const value = new Array<number>(input.length);
+	for (let i = 0; i < input.length; i++) {
+		value[i] = input.charCodeAt(i);
+	}
+	encoded.set(input, value);
+	return value;
 }
 
 /**


### PR DESCRIPTION
Fix potential memory leak due to growing an unbounded string table. Also make encoding faster.